### PR TITLE
Add a class to the root window widget to ease theming in gtk themes

### DIFF
--- a/src/meter/sink_meter.rs
+++ b/src/meter/sink_meter.rs
@@ -201,6 +201,7 @@ impl Meter for SinkMeter {
 		if data.description != self.data.description {
 			self.data.description = data.description.clone();
 			self.widgets.label.set_label(&self.data.description);
+			self.widgets.app_button.set_tooltip_text(Some(&self.data.description));
 		}
 
 		if volume_changed || data.muted != self.data.muted {

--- a/src/meter/source_meter.rs
+++ b/src/meter/source_meter.rs
@@ -203,6 +203,7 @@ impl Meter for SourceMeter {
 		if data.description != self.data.description {
 			self.data.description = data.description.clone();
 			self.widgets.label.set_label(&self.data.description);
+			self.widgets.app_button.set_tooltip_text(Some(&self.data.description));
 		}
 
 		if volume_changed || data.muted != self.data.muted {

--- a/src/meter/stream_meter.rs
+++ b/src/meter/stream_meter.rs
@@ -123,6 +123,7 @@ impl Meter for StreamMeter {
 		if data.description != self.data.description {
 			self.data.description = data.description.clone();
 			self.widgets.label.set_label(&self.data.description);
+			self.widgets.app_button.set_tooltip_text(Some(&self.data.description));
 		}
 
 		if volume_changed || data.muted != self.data.muted {

--- a/src/window/myxer.rs
+++ b/src/window/myxer.rs
@@ -134,6 +134,7 @@ impl Myxer {
 			};
 
 			window.set_geometry_hints::<gtk::ApplicationWindow>(None, Some(&geom), gdk::WindowHints::MIN_SIZE | gdk::WindowHints::MAX_SIZE);
+                        window.get_style_context().add_class("Myxer");
 			style::style(&window);
 
 			let stack_switcher = gtk::StackSwitcher::new();


### PR DESCRIPTION
This PR adds a gtk class to the root `window` widget, which makes it possible to specifically address this application in GTK themes.

With Myxer's very minimal, beautiful looks it's a nice application to integrate into a customized desktop in a way that makes it feel native to the system, so putting focus on themability here seems like a great idea, in general!
