### PR TITLE
Add a class to the root window widget to ease theming in gtk themes

### DIFF
--- a/src/window/myxer.rs
+++ b/src/window/myxer.rs
@@ -134,6 +134,7 @@ impl Myxer {
 			};
 
 			window.set_geometry_hints::<gtk::ApplicationWindow>(None, Some(&geom), gdk::WindowHints::MIN_SIZE | gdk::WindowHints::MAX_SIZE);
+			window.get_style_context().add_class("Myxer");
 			style::style(&window);
 
 			let stack_switcher = gtk::StackSwitcher::new();


### PR DESCRIPTION
This PR adds a gtk class to the root window widget, which makes it possible to specifically address this application in GTK themes.

With Myxer's very minimal, beautiful looks it's a nice application to integrate into a customized desktop in a way that makes it feel native to the system, so putting focus on themability here seems like a great idea, in general!


I very much apologize for the PR weirdness, my last PR was messed up and i was unable to reopen after fixing it,.... Sorry ^^'