### PR TITLE
Run rustfmt on all files

### DIFF
--- a/src/card.rs
+++ b/src/card.rs
@@ -3,14 +3,13 @@
  * Has a dropdown that allows the current card profile to be changed.
  */
 
+use glib::translate::FromGlib;
+use glib::translate::ToGlib;
 use gtk;
 use gtk::prelude::*;
-use glib::translate::ToGlib;
-use glib::translate::FromGlib;
 
 use crate::pulse::Pulse;
 use crate::shared::Shared;
-
 
 /**
  * Holds a Card's data.
@@ -18,27 +17,25 @@ use crate::shared::Shared;
 
 #[derive(Debug, Clone, Default)]
 pub struct CardData {
-	pub index: u32,
-	
-	pub name: String,
-	pub icon: String,
+    pub index: u32,
 
-	pub profiles: Vec<(String, String)>,
-	pub active_profile: String
+    pub name: String,
+    pub icon: String,
+
+    pub profiles: Vec<(String, String)>,
+    pub active_profile: String,
 }
-
 
 /**
  * Holds a Card's widgets.
  */
 
 struct CardWidgets {
-	root: gtk::Box,
-	
-	label: gtk::Label,
-	combo: gtk::ComboBoxText,
-}
+    root: gtk::Box,
 
+    label: gtk::Label,
+    combo: gtk::ComboBoxText,
+}
 
 /**
  * A widget representing a pulseaudio sound card.
@@ -46,122 +43,126 @@ struct CardWidgets {
  */
 
 pub struct Card {
-	pub widget: gtk::Box,
-	widgets: CardWidgets,
+    pub widget: gtk::Box,
+    widgets: CardWidgets,
 
-	data: CardData,
-	pulse: Option<Shared<Pulse>>,
-	combo_connect_id: Option<glib::signal::SignalHandlerId>,
+    data: CardData,
+    pulse: Option<Shared<Pulse>>,
+    combo_connect_id: Option<glib::signal::SignalHandlerId>,
 }
 
 impl Card {
+    /**
+     * Constructs the GTK widgets required for the card widget.
+     */
 
-	/**
-	 * Constructs the GTK widgets required for the card widget.
-	 */
+    fn build() -> CardWidgets {
+        let root = gtk::Box::new(gtk::Orientation::Horizontal, 0);
+        root.set_widget_name("card");
 
-	fn build() -> CardWidgets {
-		let root = gtk::Box::new(gtk::Orientation::Horizontal, 0);
-		root.set_widget_name("card");
+        let inner = gtk::Box::new(gtk::Orientation::Vertical, 0);
+        inner.set_border_width(3);
+        root.pack_start(&inner, true, true, 3);
 
-		let inner = gtk::Box::new(gtk::Orientation::Vertical, 0);
-		inner.set_border_width(3);
-		root.pack_start(&inner, true, true, 3);
+        let label_box = gtk::Box::new(gtk::Orientation::Horizontal, 0);
+        label_box.set_border_width(0);
+        inner.pack_start(&label_box, false, false, 3);
 
-		let label_box = gtk::Box::new(gtk::Orientation::Horizontal, 0);
-		label_box.set_border_width(0);
-		inner.pack_start(&label_box, false, false, 3);
+        let icon = gtk::Image::from_icon_name(Some("audio-card"), gtk::IconSize::LargeToolbar);
+        let label = gtk::Label::new(Some("Unknown Card"));
 
-		let icon = gtk::Image::from_icon_name(Some("audio-card"), gtk::IconSize::LargeToolbar);
-		let label = gtk::Label::new(Some("Unknown Card"));
+        label_box.pack_start(&icon, false, false, 3);
+        label_box.pack_start(&label, false, true, 3);
 
-		label_box.pack_start(&icon, false, false, 3);
-		label_box.pack_start(&label, false, true, 3);
-		
-		let combo = gtk::ComboBoxText::new();
-		inner.pack_start(&combo, false, false, 6);
+        let combo = gtk::ComboBoxText::new();
+        inner.pack_start(&combo, false, false, 6);
 
-		CardWidgets {
-			root,
-			label,
-			combo
-		}
-	}
+        CardWidgets { root, label, combo }
+    }
 
+    /**
+     * Creates a new card widget.
+     */
 
-	/**
-	 * Creates a new card widget.
-	 */
+    pub fn new(pulse: Option<Shared<Pulse>>) -> Self {
+        let widgets = Card::build();
+        Self {
+            widget: widgets.root.clone(),
+            widgets,
+            data: CardData::default(),
+            pulse,
+            combo_connect_id: None,
+        }
+    }
 
-	pub fn new(pulse: Option<Shared<Pulse>>) -> Self {
-		let widgets = Card::build();
-		Self {
-			widget: widgets.root.clone(), widgets,
-			data: CardData::default(),
-			pulse,
-			combo_connect_id: None
-		}
-	}
+    /**
+     * Disconnect's a card widget from the Pulse instance,
+     * in the event that significant information has changed for the callbacks to be invalid.
+     */
 
+    fn disconnect(&mut self) {
+        if self.combo_connect_id.is_some() {
+            self.widgets
+                .combo
+                .disconnect(glib::signal::SignalHandlerId::from_glib(
+                    self.combo_connect_id.as_ref().unwrap().to_glib(),
+                ));
+        }
+    }
 
-	/**
-	 * Disconnect's a card widget from the Pulse instance,
-	 * in the event that significant information has changed for the callbacks to be invalid.
-	 */
+    /**
+     * Connects a callback to the widget's dropdown,
+     * so that changing the selected option changes the card's profile.
+     * If the Pulse instance is None, the callback is not bound.
+     */
 
-	fn disconnect(&mut self) {
-		if self.combo_connect_id.is_some() {
-			self.widgets.combo.disconnect(glib::signal::SignalHandlerId::from_glib(self.combo_connect_id.as_ref().unwrap().to_glib()));
-		}
-	}
+    fn connect(&mut self) {
+        if self.pulse.is_none() {
+            return;
+        }
 
+        let index = self.data.index;
+        let pulse = self.pulse.as_ref().unwrap().clone();
+        self.combo_connect_id = Some(self.widgets.combo.connect_changed(move |combo| {
+            pulse
+                .borrow_mut()
+                .set_card_profile(index, &String::from(combo.get_active_id().unwrap()));
+        }));
+    }
 
-	/**
-	 * Connects a callback to the widget's dropdown,
-	 * so that changing the selected option changes the card's profile.
-	 * If the Pulse instance is None, the callback is not bound.
-	 */
+    /**
+     * Updates the Card's data, and visually refreshes the required components.
+     */
 
-	fn connect(&mut self) {
-		if self.pulse.is_none() { return; }
+    pub fn set_data(&mut self, data: &CardData) {
+        if data.index != self.data.index {
+            self.data.index = data.index;
+            self.disconnect();
+            self.connect();
+        }
 
-		let index = self.data.index;
-		let pulse = self.pulse.as_ref().unwrap().clone();
-		self.combo_connect_id = Some(self.widgets.combo.connect_changed(move |combo| {
-			pulse.borrow_mut().set_card_profile(index, &String::from(combo.get_active_id().unwrap()));
-		}));
-	}
+        if data.name != self.data.name {
+            self.data.name = data.name.clone();
+            self.widgets.label.set_label(&self.data.name);
+        }
 
+        if data.profiles.len() != self.data.profiles.len() {
+            self.disconnect();
+            self.data.profiles = data.profiles.clone();
+            self.widgets.combo.remove_all();
+            for (i, n) in &data.profiles {
+                self.widgets.combo.append(Some(&i), &n);
+            }
+            self.connect();
+        }
 
-	/**
-	 * Updates the Card's data, and visually refreshes the required components.
-	 */
-
-	pub fn set_data(&mut self, data: &CardData) {
-		if data.index != self.data.index {
-			self.data.index = data.index;
-			self.disconnect();
-			self.connect();
-		}
-
-		if data.name != self.data.name {
-			self.data.name = data.name.clone();
-			self.widgets.label.set_label(&self.data.name);
-		}
-
-		if data.profiles.len() != self.data.profiles.len() {
-			self.disconnect();
-			self.data.profiles = data.profiles.clone();
-			self.widgets.combo.remove_all();
-			for (i, n) in &data.profiles { self.widgets.combo.append(Some(&i), &n); }
-			self.connect();
-		}
-
-		if data.active_profile != self.data.active_profile {
-			self.disconnect();
-			self.data.active_profile = data.active_profile.clone();
-			self.widgets.combo.set_active_id(Some(&self.data.active_profile));
-			self.connect();
-		}
-	}
+        if data.active_profile != self.data.active_profile {
+            self.disconnect();
+            self.data.active_profile = data.active_profile.clone();
+            self.widgets
+                .combo
+                .set_active_id(Some(&self.data.active_profile));
+            self.connect();
+        }
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,13 +8,12 @@ use gio::prelude::*;
 mod card;
 mod meter;
 mod pulse;
-mod window;
 mod shared;
+mod window;
 
 use pulse::Pulse;
-use window::Myxer;
 use shared::Shared;
-
+use window::Myxer;
 
 /**
  * Attempts to start the application.
@@ -26,19 +25,18 @@ use shared::Shared;
  */
 
 fn main() {
-	let pulse = Shared::new(Pulse::new());
-	
-	let app = gtk::Application::new(Some("com.aurailus.myxer"), Default::default())
-		.expect("Failed to initialize GTK application.");
+    let pulse = Shared::new(Pulse::new());
 
-	let pulse_clone = pulse.clone();
-	app.connect_activate(|app| drop(app.register::<gio::Cancellable>(None)));
-	app.connect_startup(move |app| activate(app, &pulse_clone));
-	app.run(&[]);
+    let app = gtk::Application::new(Some("com.aurailus.myxer"), Default::default())
+        .expect("Failed to initialize GTK application.");
 
-	pulse.borrow_mut().cleanup();
+    let pulse_clone = pulse.clone();
+    app.connect_activate(|app| drop(app.register::<gio::Cancellable>(None)));
+    app.connect_startup(move |app| activate(app, &pulse_clone));
+    app.run(&[]);
+
+    pulse.borrow_mut().cleanup();
 }
-
 
 /**
  * Called by GTK when the application has initialized. Creates the main Myxer
@@ -46,10 +44,10 @@ fn main() {
  */
 
 fn activate(app: &gtk::Application, pulse: &Shared<Pulse>) {
-	let mut myxer = Myxer::new(app, pulse);
+    let mut myxer = Myxer::new(app, pulse);
 
-	glib::timeout_add_local(1000 / 30, move || {
-		myxer.update();
-		glib::Continue(true)
-	});
+    glib::timeout_add_local(1000 / 30, move || {
+        myxer.update();
+        glib::Continue(true)
+    });
 }

--- a/src/meter/meter.rs
+++ b/src/meter/meter.rs
@@ -4,10 +4,10 @@
 
 use gtk;
 use gtk::prelude::*;
-use libpulse::volume::{ Volume, ChannelVolumes };
+use libpulse::volume::{ChannelVolumes, Volume};
 
+use crate::pulse::{Pulse, StreamType};
 use crate::shared::Shared;
-use crate::pulse::{ Pulse, StreamType };
 
 /** The maximum natural volume, i.e. 100% */
 pub const MAX_NATURAL_VOL: u32 = 65536;
@@ -19,13 +19,20 @@ pub const MAX_SCALE_VOL: u32 = (MAX_NATURAL_VOL as f64 * 1.5) as u32;
 pub const SCALE_STEP: f64 = MAX_NATURAL_VOL as f64 / 20.0;
 
 /** The icon names for the input meter statuses. */
-pub const INPUT_ICONS: [&str; 4] = [ "microphone-sensitivity-muted-symbolic", "microphone-sensitivity-low-symbolic",
-	"microphone-sensitivity-medium-symbolic", "microphone-sensitivity-high-symbolic" ];
+pub const INPUT_ICONS: [&str; 4] = [
+    "microphone-sensitivity-muted-symbolic",
+    "microphone-sensitivity-low-symbolic",
+    "microphone-sensitivity-medium-symbolic",
+    "microphone-sensitivity-high-symbolic",
+];
 
 /** The icon names for the output meter statuses. */
-pub const OUTPUT_ICONS: [&str; 4] = [ "audio-volume-muted-symbolic", "audio-volume-low-symbolic",
-	"audio-volume-medium-symbolic", "audio-volume-high-symbolic" ];
-
+pub const OUTPUT_ICONS: [&str; 4] = [
+    "audio-volume-muted-symbolic",
+    "audio-volume-low-symbolic",
+    "audio-volume-medium-symbolic",
+    "audio-volume-high-symbolic",
+];
 
 /**
  * Holds a Meter widget's display data.
@@ -33,37 +40,35 @@ pub const OUTPUT_ICONS: [&str; 4] = [ "audio-volume-muted-symbolic", "audio-volu
 
 #[derive(Debug, Clone, Default)]
 pub struct MeterData {
-	pub t: StreamType,
-	pub index: u32,
+    pub t: StreamType,
+    pub index: u32,
 
-	pub name: String,
-	pub icon: String,
-	pub description: String,
+    pub name: String,
+    pub icon: String,
+    pub description: String,
 
-	pub volume: ChannelVolumes,
-	pub muted: bool,
+    pub volume: ChannelVolumes,
+    pub muted: bool,
 }
-
 
 /**
  * Holds references to a Meter's widgets.
  */
 
 pub struct MeterWidgets {
-	pub root: gtk::Box,
-	
-	pub icon: gtk::Image,
-	pub label: gtk::Label,
-	pub select: gtk::Button,
-	pub app_button: gtk::Button,
+    pub root: gtk::Box,
 
-	pub status: gtk::Button,
-	pub status_icon: gtk::Image,
+    pub icon: gtk::Image,
+    pub label: gtk::Label,
+    pub select: gtk::Button,
+    pub app_button: gtk::Button,
 
-	pub scales_outer: gtk::Box,
-	pub scales_inner: gtk::Box,
+    pub status: gtk::Button,
+    pub status_icon: gtk::Image,
+
+    pub scales_outer: gtk::Box,
+    pub scales_inner: gtk::Box,
 }
-
 
 /**
  * The base trait for all Meter widgets.
@@ -72,196 +77,196 @@ pub struct MeterWidgets {
  */
 
 pub trait Meter {
-	/**
-	 * Gets the meter's underlying stream index.
-	 */
+    /**
+     * Gets the meter's underlying stream index.
+     */
 
-	fn get_index(&self) -> u32;
+    fn get_index(&self) -> u32;
 
+    /**
+     * Sets whether or not to split channels into individual meters.
+     *
+     * * `split` - Whether or not channels should be separated.
+     */
 
-	/**
-	 * Sets whether or not to split channels into individual meters.
-	 *
-	 * * `split` - Whether or not channels should be separated.
-	 */
+    fn split_channels(&mut self, split: bool);
 
-	fn split_channels(&mut self, split: bool);
+    /**
+     * Updates the meter's data, and visually refreshes the required widgets.
+     */
 
+    fn set_data(&mut self, data: &MeterData);
 
-	/**
-	 * Updates the meter's data, and visually refreshes the required widgets.
-	 */
+    /**
+     * Sets the meter's current peak.
+     *
+     * * `peak` - The meter's peak, or None if no peak indicator should be shown.
+     */
 
-	fn set_data(&mut self, data: &MeterData);
-
-
-	/**
-	 * Sets the meter's current peak.
-	 *
-	 * * `peak` - The meter's peak, or None if no peak indicator should be shown.
-	 */
-
-	fn set_peak(&mut self, peak: Option<u32>);
+    fn set_peak(&mut self, peak: Option<u32>);
 }
 
 impl dyn Meter {
+    /**
+     * Builds a scale. This may be for a single channel, or all channels.
+     */
 
-	/**
-	 * Builds a scale. This may be for a single channel, or all channels.
-	 */
+    fn build_scale() -> gtk::Scale {
+        let scale = gtk::Scale::with_range(
+            gtk::Orientation::Vertical,
+            0.0,
+            MAX_SCALE_VOL as f64,
+            SCALE_STEP,
+        );
 
-	fn build_scale() -> gtk::Scale {
-		let scale = gtk::Scale::with_range(gtk::Orientation::Vertical, 0.0, MAX_SCALE_VOL as f64, SCALE_STEP);
+        scale.set_inverted(true);
+        scale.set_draw_value(false);
+        scale.set_sensitive(false);
+        scale.set_increments(SCALE_STEP, SCALE_STEP);
+        scale.set_restrict_to_fill_level(false);
 
-		scale.set_inverted(true);
-		scale.set_draw_value(false);
-		scale.set_sensitive(false);
-		scale.set_increments(SCALE_STEP, SCALE_STEP);
-		scale.set_restrict_to_fill_level(false);
+        scale.add_mark(0.0, gtk::PositionType::Right, Some(""));
+        scale.add_mark(MAX_SCALE_VOL as f64, gtk::PositionType::Right, Some(""));
+        scale.add_mark(MAX_NATURAL_VOL as f64, gtk::PositionType::Right, Some(""));
 
-		scale.add_mark(0.0, gtk::PositionType::Right, Some(""));
-		scale.add_mark(MAX_SCALE_VOL as f64, gtk::PositionType::Right, Some(""));
-		scale.add_mark(MAX_NATURAL_VOL as f64, gtk::PositionType::Right, Some(""));
+        scale
+    }
 
-		scale
-	}
+    /**
+     * Builds the required scales for a Meter.
+     * This may be one or more, depending on the state of the `split` variable.
+     *
+     * * `pulse` - The pulse store to bind events to.
+     * * `data`  - The meter data to base the scales off of.
+     * * `split` - Whether or not one merged bar should be created, or individual bars for each channel.
+     */
 
+    pub fn build_scales(pulse: &Shared<Pulse>, data: &MeterData, split: bool) -> gtk::Box {
+        let t = data.t;
+        let index = data.index;
 
-	/**
-	 * Builds the required scales for a Meter.
-	 * This may be one or more, depending on the state of the `split` variable.
-	 *
-	 * * `pulse` - The pulse store to bind events to.
-	 * * `data`  - The meter data to base the scales off of.
-	 * * `split` - Whether or not one merged bar should be created, or individual bars for each channel.
-	 */
+        let pulse = pulse.clone();
+        let scales_box = gtk::Box::new(gtk::Orientation::Horizontal, 0);
 
-	pub fn build_scales(pulse: &Shared<Pulse>, data: &MeterData, split: bool) -> gtk::Box {
-		let t = data.t;
-		let index = data.index;
+        if split {
+            for _ in 0..data.volume.len() {
+                let scale = Meter::build_scale();
+                let pulse = pulse.clone();
 
-		let pulse = pulse.clone();
-		let scales_box = gtk::Box::new(gtk::Orientation::Horizontal, 0);
+                scale.connect_change_value(move |scale, _, val| {
+                    let parent = scale.get_parent().unwrap().downcast::<gtk::Box>().unwrap();
+                    let children = parent.get_children();
 
-		if split {
-			for _ in 0 .. data.volume.len() {
-				let scale = Meter::build_scale();
-				let pulse = pulse.clone();
+                    let mut volumes = ChannelVolumes::default();
 
-				scale.connect_change_value(move |scale, _, val| {
-					let parent = scale.get_parent().unwrap().downcast::<gtk::Box>().unwrap();
-					let children = parent.get_children();
-					
-					let mut volumes = ChannelVolumes::default();
-					
-					// So, if you're wondering why rev() is necessary or why I set the len after or why this is horrible in general,
-					// Check out libpulse_binding::volumes::ChannelVolumes::set, and you'll see ._.
-					for (i, w) in children.iter().enumerate().rev() {
-						let s = w.clone().downcast::<gtk::Scale>().unwrap();
-						let value = if *scale == s { val } else { s.get_value() };
-						let volume = Volume(value as u32);
-						volumes.set(i as u8 + 1, volume);
-					}
+                    // So, if you're wondering why rev() is necessary or why I set the len after or why this is horrible in general,
+                    // Check out libpulse_binding::volumes::ChannelVolumes::set, and you'll see ._.
+                    for (i, w) in children.iter().enumerate().rev() {
+                        let s = w.clone().downcast::<gtk::Scale>().unwrap();
+                        let value = if *scale == s { val } else { s.get_value() };
+                        let volume = Volume(value as u32);
+                        volumes.set(i as u8 + 1, volume);
+                    }
 
-					volumes.set_len(children.len() as u8);
+                    volumes.set_len(children.len() as u8);
 
-					pulse.borrow_mut().set_volume(t, index, volumes);
-					gtk::Inhibit(false)
-				});
+                    pulse.borrow_mut().set_volume(t, index, volumes);
+                    gtk::Inhibit(false)
+                });
 
-				scales_box.pack_start(&scale, false, false, 0);
-			}
-		}
-		else {
-			let scale = Meter::build_scale();
-			let channels = data.volume.len();
-			let pulse = pulse.clone();
-			scale.connect_change_value(move |_, _, value| {
-				let mut volumes = ChannelVolumes::default();
-				volumes.set_len(channels);
-				volumes.set(channels, Volume(value as u32));
-				pulse.borrow_mut().set_volume(t, index, volumes);
-				gtk::Inhibit(false)
-			});
-			scales_box.pack_start(&scale, false, false, 0);
-		}
+                scales_box.pack_start(&scale, false, false, 0);
+            }
+        } else {
+            let scale = Meter::build_scale();
+            let channels = data.volume.len();
+            let pulse = pulse.clone();
+            scale.connect_change_value(move |_, _, value| {
+                let mut volumes = ChannelVolumes::default();
+                volumes.set_len(channels);
+                volumes.set(channels, Volume(value as u32));
+                pulse.borrow_mut().set_volume(t, index, volumes);
+                gtk::Inhibit(false)
+            });
+            scales_box.pack_start(&scale, false, false, 0);
+        }
 
-		scales_box.show_all();
-		scales_box
-	}
+        scales_box.show_all();
+        scales_box
+    }
 
+    /**
+     * Initializes all of the Widgets to make a meter, and returns them.
+     */
 
-	/**
-	 * Initializes all of the Widgets to make a meter, and returns them.
-	 */
-	 
-	pub fn build_meter() -> MeterWidgets {
-		let root = gtk::Box::new(gtk::Orientation::Vertical, 0);
-		root.set_widget_name("meter");
+    pub fn build_meter() -> MeterWidgets {
+        let root = gtk::Box::new(gtk::Orientation::Vertical, 0);
+        root.set_widget_name("meter");
 
-		root.set_orientation(gtk::Orientation::Vertical);
-		root.set_hexpand(false);
-		root.set_size_request(86, -1);
+        root.set_orientation(gtk::Orientation::Vertical);
+        root.set_hexpand(false);
+        root.set_size_request(86, -1);
 
-		let app_button = gtk::Button::new();
-		app_button.set_widget_name("top");
-		app_button.get_style_context().add_class("flat");
-		let label_container = gtk::Box::new(gtk::Orientation::Vertical, 0);
-		app_button.add(&label_container);
+        let app_button = gtk::Button::new();
+        app_button.set_widget_name("top");
+        app_button.get_style_context().add_class("flat");
+        let label_container = gtk::Box::new(gtk::Orientation::Vertical, 0);
+        app_button.add(&label_container);
 
-		let icon = gtk::Image::from_icon_name(Some("audio-volume-muted-symbolic"), gtk::IconSize::Dnd);
+        let icon =
+            gtk::Image::from_icon_name(Some("audio-volume-muted-symbolic"), gtk::IconSize::Dnd);
 
-		let label = gtk::Label::new(Some("Unknown"));
-		label.set_widget_name("app_label");
+        let label = gtk::Label::new(Some("Unknown"));
+        label.set_widget_name("app_label");
 
-		label.set_size_request(-1, 42);
-		label.set_justify(gtk::Justification::Center);
-		label.set_ellipsize(pango::EllipsizeMode::End);
-		label.set_line_wrap_mode(pango::WrapMode::WordChar);
-		label.set_max_width_chars(8);
-		label.set_line_wrap(true);
-		label.set_lines(2);
+        label.set_size_request(-1, 42);
+        label.set_justify(gtk::Justification::Center);
+        label.set_ellipsize(pango::EllipsizeMode::End);
+        label.set_line_wrap_mode(pango::WrapMode::WordChar);
+        label.set_max_width_chars(8);
+        label.set_line_wrap(true);
+        label.set_lines(2);
 
-		label_container.pack_end(&label, false, true, 0);
-		label_container.pack_end(&icon, false, false, 3);
+        label_container.pack_end(&label, false, true, 0);
+        label_container.pack_end(&icon, false, false, 3);
 
-		let select = gtk::Button::new();
-		select.set_widget_name("app_select");
-		select.get_style_context().add_class("flat");
+        let select = gtk::Button::new();
+        select.set_widget_name("app_select");
+        select.get_style_context().add_class("flat");
 
-		let scales_outer = gtk::Box::new(gtk::Orientation::Horizontal, 0);
-		let scales_inner = gtk::Box::new(gtk::Orientation::Horizontal, 0);
-		scales_outer.pack_start(&scales_inner, true, false, 0);
+        let scales_outer = gtk::Box::new(gtk::Orientation::Horizontal, 0);
+        let scales_inner = gtk::Box::new(gtk::Orientation::Horizontal, 0);
+        scales_outer.pack_start(&scales_inner, true, false, 0);
 
-		let status_box = gtk::Box::new(gtk::Orientation::Horizontal, 0);
-		let status_icon = gtk::Image::from_icon_name(Some("audio-volume-muted-symbolic"), gtk::IconSize::Button);
-		
-		let status = gtk::Button::new();
-		status.set_widget_name("mute_toggle");
-		status_box.pack_start(&status, true, false, 0);
-		
-		status.set_image(Some(&status_icon));
-		status.set_always_show_image(true);
-		status.get_style_context().add_class("flat");
-		status.get_style_context().add_class("muted");
+        let status_box = gtk::Box::new(gtk::Orientation::Horizontal, 0);
+        let status_icon =
+            gtk::Image::from_icon_name(Some("audio-volume-muted-symbolic"), gtk::IconSize::Button);
 
-		root.pack_end(&status_box, false, false, 3);
-		root.pack_end(&scales_outer, true, true, 2);
-		root.pack_start(&app_button, false, false, 0);
+        let status = gtk::Button::new();
+        status.set_widget_name("mute_toggle");
+        status_box.pack_start(&status, true, false, 0);
 
-		MeterWidgets {
-			root,
-			
-			icon,
-			label,
-			select,
-			app_button,
-			
-			status,
-			status_icon,
+        status.set_image(Some(&status_icon));
+        status.set_always_show_image(true);
+        status.get_style_context().add_class("flat");
+        status.get_style_context().add_class("muted");
 
-			scales_outer,
-			scales_inner
-		}
-	}
+        root.pack_end(&status_box, false, false, 3);
+        root.pack_end(&scales_outer, true, true, 2);
+        root.pack_start(&app_button, false, false, 0);
+
+        MeterWidgets {
+            root,
+
+            icon,
+            label,
+            select,
+            app_button,
+
+            status,
+            status_icon,
+
+            scales_outer,
+            scales_inner,
+        }
+    }
 }

--- a/src/meter/sink_meter.rs
+++ b/src/meter/sink_meter.rs
@@ -2,15 +2,14 @@
  * A specialized meter for representing sinks.
  */
 
+use glib::translate::{FromGlib, ToGlib};
 use gtk;
 use gtk::prelude::*;
-use glib::translate::{ ToGlib, FromGlib };
 
+use super::meter::{Meter, MeterData, MeterWidgets};
+use super::meter::{MAX_NATURAL_VOL, MAX_SCALE_VOL, OUTPUT_ICONS};
 use crate::pulse::Pulse;
 use crate::shared::Shared;
-use super::meter::{ Meter, MeterWidgets, MeterData };
-use super::meter::{ MAX_NATURAL_VOL, MAX_SCALE_VOL, OUTPUT_ICONS };
-
 
 /**
  * A meter widget representing a sink.
@@ -18,236 +17,291 @@ use super::meter::{ MAX_NATURAL_VOL, MAX_SCALE_VOL, OUTPUT_ICONS };
  */
 
 pub struct SinkMeter {
-	pub widget: gtk::Box,
+    pub widget: gtk::Box,
 
-	data: MeterData,
-	widgets: MeterWidgets,
-	pulse: Shared<Pulse>,
+    data: MeterData,
+    widgets: MeterWidgets,
+    pulse: Shared<Pulse>,
 
-	split: bool,
-	peak: Option<u32>,
+    split: bool,
+    peak: Option<u32>,
 
-	l_id: Option<glib::signal::SignalHandlerId>,
-	s_id: Option<glib::signal::SignalHandlerId>,
+    l_id: Option<glib::signal::SignalHandlerId>,
+    s_id: Option<glib::signal::SignalHandlerId>,
 }
 
 impl SinkMeter {
+    /**
+     * Creates a new SinkMeter.
+     */
 
-	/**
-	 * Creates a new SinkMeter.
-	 */
+    pub fn new(pulse: Shared<Pulse>) -> Self {
+        let widgets = Meter::build_meter();
+        Self {
+            widget: widgets.root.clone(),
 
-	pub fn new(pulse: Shared<Pulse>) -> Self {
-		let widgets = Meter::build_meter();
-		Self {
-			widget: widgets.root.clone(),
-			
-			pulse,
-			widgets,
-			data: MeterData::default(),
+            pulse,
+            widgets,
+            data: MeterData::default(),
 
-			split: false, peak: None, s_id: None, l_id: None
-		}
-	}
+            split: false,
+            peak: None,
+            s_id: None,
+            l_id: None,
+        }
+    }
 
+    /**
+     * Rebuilds widgets that are dependent on the Pulse instance or the sink index.
+     * Reconnects the widgets to the Pulse instance, if one is provided.
+     */
 
-	/**
-	 * Rebuilds widgets that are dependent on the Pulse instance or the sink index.
-	 * Reconnects the widgets to the Pulse instance, if one is provided.
-	 */
+    fn rebuild_widgets(&mut self) {
+        let scales = Meter::build_scales(&self.pulse, &self.data, self.split);
+        self.widgets.scales_outer.remove(&self.widgets.scales_inner);
+        self.widgets
+            .scales_outer
+            .pack_start(&scales, true, false, 0);
+        self.widgets.scales_inner = scales;
+        self.update_widgets();
 
-	fn rebuild_widgets(&mut self) {
-		let scales = Meter::build_scales(&self.pulse, &self.data, self.split);
-		self.widgets.scales_outer.remove(&self.widgets.scales_inner);
-		self.widgets.scales_outer.pack_start(&scales, true, false, 0);
-		self.widgets.scales_inner = scales;
-		self.update_widgets();
+        let t = self.data.t;
+        let index = self.data.index;
+        let pulse = self.pulse.clone();
 
-		let t 		= self.data.t;
-		let index = self.data.index;
-		let pulse = self.pulse.clone();
+        if self.s_id.is_some() {
+            self.widgets
+                .status
+                .disconnect(glib::signal::SignalHandlerId::from_glib(
+                    self.s_id.as_ref().unwrap().to_glib(),
+                ))
+        }
+        self.s_id = Some(self.widgets.status.connect_clicked(move |status| {
+            pulse
+                .borrow_mut()
+                .set_muted(t, index, !status.get_style_context().has_class("muted"));
+        }));
 
-		if self.s_id.is_some() { self.widgets.status.disconnect(glib::signal::SignalHandlerId::from_glib(self.s_id.as_ref().unwrap().to_glib())) }
-		self.s_id = Some(self.widgets.status.connect_clicked(move |status| {
-			pulse.borrow_mut().set_muted(t, index,
-				!status.get_style_context().has_class("muted"));
-		}));
+        let pulse = self.pulse.clone();
+        let index = self.data.index;
 
-		let pulse = self.pulse.clone();
-		let index	= self.data.index;
+        if self.l_id.is_some() {
+            self.widgets
+                .app_button
+                .disconnect(glib::signal::SignalHandlerId::from_glib(
+                    self.l_id.as_ref().unwrap().to_glib(),
+                ))
+        }
+        self.l_id = Some(self.widgets.app_button.connect_clicked(move |trigger| {
+            SinkMeter::show_popup(&trigger, &pulse, index);
+        }));
+    }
 
-		if self.l_id.is_some() { self.widgets.app_button.disconnect(
-			glib::signal::SignalHandlerId::from_glib(self.l_id.as_ref().unwrap().to_glib())) }
-		self.l_id = Some(self.widgets.app_button.connect_clicked(move |trigger| {
-			SinkMeter::show_popup(&trigger, &pulse, index);
-		}));
-	}
+    /**
+     * Updates each scale widget to reflect the current volume level.
+     */
 
+    fn update_widgets(&mut self) {
+        for (i, v) in self.data.volume.get().iter().enumerate() {
+            if let Some(scale) = self.widgets.scales_inner.get_children().get(i) {
+                let scale = scale
+                    .clone()
+                    .downcast::<gtk::Scale>()
+                    .expect("Scales box has non-scale children.");
+                scale.set_sensitive(!self.data.muted);
+                scale.set_value(v.0 as f64);
+            }
+        }
+    }
 
-	/**
-	 * Updates each scale widget to reflect the current volume level.
-	 */
+    /**
+     * Shows a popup menu on the top button, with items to set
+     * the Sink as default, and change the visible sink.
+     */
 
-	fn update_widgets(&mut self) {
-		for (i, v) in self.data.volume.get().iter().enumerate() {
-			if let Some(scale) = self.widgets.scales_inner.get_children().get(i) {
-				let scale = scale.clone().downcast::<gtk::Scale>().expect("Scales box has non-scale children.");
-				scale.set_sensitive(!self.data.muted);
-				scale.set_value(v.0 as f64);
-			}
-		}
-	}
+    fn show_popup(trigger: &gtk::Button, pulse_shr: &Shared<Pulse>, index: u32) {
+        let pulse = pulse_shr.borrow_mut();
+        let root = gtk::PopoverMenu::new();
+        root.set_border_width(6);
 
+        let menu = gtk::Box::new(gtk::Orientation::Vertical, 0);
+        menu.set_size_request(132, -1);
+        root.add(&menu);
 
-	/**
-	 * Shows a popup menu on the top button, with items to set
-	 * the Sink as default, and change the visible sink.
-	 */
+        // let split_channels = gtk::ModelButton::new();
+        // split_channels.set_property_text(Some("Split Channels"));
+        // split_channels.set_action_name(Some("app.split_channels"));
+        // menu.add(&split_channels);
 
-	fn show_popup(trigger: &gtk::Button, pulse_shr: &Shared<Pulse>, index: u32) {
-		let pulse = pulse_shr.borrow_mut();
-		let root = gtk::PopoverMenu::new();
-		root.set_border_width(6);
+        let set_default = gtk::ModelButton::new();
+        set_default.set_property_role(gtk::ButtonRole::Check);
+        set_default.set_property_text(Some("Set as Default"));
+        set_default.set_property_active(pulse.default_sink == index);
+        set_default.set_sensitive(pulse.default_sink != index);
 
-		let menu = gtk::Box::new(gtk::Orientation::Vertical, 0);
-		menu.set_size_request(132, -1);
-		root.add(&menu);
-		
-		// let split_channels = gtk::ModelButton::new();
-		// split_channels.set_property_text(Some("Split Channels"));
-		// split_channels.set_action_name(Some("app.split_channels"));
-		// menu.add(&split_channels);
+        let pulse_clone = pulse_shr.clone();
+        set_default.connect_clicked(move |set_default| {
+            pulse_clone.borrow_mut().set_default_sink(index);
+            set_default.set_property_active(true);
+            set_default.set_sensitive(false);
+        });
+        menu.add(&set_default);
 
-		let set_default = gtk::ModelButton::new();
-		set_default.set_property_role(gtk::ButtonRole::Check);
-		set_default.set_property_text(Some("Set as Default"));
-		set_default.set_property_active(pulse.default_sink == index);
-		set_default.set_sensitive(pulse.default_sink != index);
-			
-		let pulse_clone = pulse_shr.clone();
-		set_default.connect_clicked(move |set_default| {
-			pulse_clone.borrow_mut().set_default_sink(index);
-			set_default.set_property_active(true);
-			set_default.set_sensitive(false);
-		});
-		menu.add(&set_default);
+        if pulse.sinks.len() >= 2 {
+            menu.pack_start(&gtk::SeparatorMenuItem::new(), false, false, 3);
 
-		if pulse.sinks.len() >= 2 {
-			menu.pack_start(&gtk::SeparatorMenuItem::new(), false, false, 3);
+            let label = gtk::Label::new(Some("Visible Output"));
+            label.set_sensitive(false);
+            menu.pack_start(&label, true, true, 3);
 
-			let label = gtk::Label::new(Some("Visible Output"));
-			label.set_sensitive(false);
-			menu.pack_start(&label, true, true, 3);
-			
-			for (i, v) in &pulse.sinks {
-				let button = gtk::ModelButton::new();
-				button.set_property_role(gtk::ButtonRole::Radio);
-				button.set_property_active(v.data.index == index);
-				let button_label = gtk::Label::new(Some(&v.data.description));
-				button_label.set_ellipsize(pango::EllipsizeMode::End);
-				button_label.set_max_width_chars(18);
-				button.get_child().unwrap().downcast::<gtk::Box>().unwrap().add(&button_label);
-				
-				let i = *i;
-				let root = root.clone();
-				let pulse_clone = pulse_shr.clone();
-				button.connect_clicked(move |_| {
-					pulse_clone.borrow_mut().set_active_sink(i);
-					root.popdown();
-				});
-				
-				menu.add(&button);
-			}
-		}
+            for (i, v) in &pulse.sinks {
+                let button = gtk::ModelButton::new();
+                button.set_property_role(gtk::ButtonRole::Radio);
+                button.set_property_active(v.data.index == index);
+                let button_label = gtk::Label::new(Some(&v.data.description));
+                button_label.set_ellipsize(pango::EllipsizeMode::End);
+                button_label.set_max_width_chars(18);
+                button
+                    .get_child()
+                    .unwrap()
+                    .downcast::<gtk::Box>()
+                    .unwrap()
+                    .add(&button_label);
 
-		for child in &root.get_children() { child.show_all(); }
-		root.set_relative_to(Some(trigger));
-		root.popup();
-	}
+                let i = *i;
+                let root = root.clone();
+                let pulse_clone = pulse_shr.clone();
+                button.connect_clicked(move |_| {
+                    pulse_clone.borrow_mut().set_active_sink(i);
+                    root.popdown();
+                });
+
+                menu.add(&button);
+            }
+        }
+
+        for child in &root.get_children() {
+            child.show_all();
+        }
+        root.set_relative_to(Some(trigger));
+        root.popup();
+    }
 }
 
 impl Meter for SinkMeter {
-	fn get_index(&self) -> u32 {
-		self.data.index
-	}
+    fn get_index(&self) -> u32 {
+        self.data.index
+    }
 
-	fn split_channels(&mut self, split: bool) {
-		if self.split == split { return }
-		self.split = split;
-		self.rebuild_widgets();
-	}
+    fn split_channels(&mut self, split: bool) {
+        if self.split == split {
+            return;
+        }
+        self.split = split;
+        self.rebuild_widgets();
+    }
 
-	fn set_data(&mut self, data: &MeterData) {
-		let volume_old = self.data.volume;
-		let volume_changed = data.volume != volume_old;
+    fn set_data(&mut self, data: &MeterData) {
+        let volume_old = self.data.volume;
+        let volume_changed = data.volume != volume_old;
 
-		if data.t != self.data.t || data.index != self.data.index || data.volume.len() != self.data.volume.len() {
-			self.data.t = data.t;
-			self.data.volume = data.volume;
-			self.data.index = data.index;
-			self.rebuild_widgets();
-		}
+        if data.t != self.data.t
+            || data.index != self.data.index
+            || data.volume.len() != self.data.volume.len()
+        {
+            self.data.t = data.t;
+            self.data.volume = data.volume;
+            self.data.index = data.index;
+            self.rebuild_widgets();
+        }
 
-		if data.icon != self.data.icon {
-			self.data.icon = data.icon.clone();
-			self.widgets.icon.set_from_icon_name(Some(&self.data.icon), gtk::IconSize::Dnd);
-		}
+        if data.icon != self.data.icon {
+            self.data.icon = data.icon.clone();
+            self.widgets
+                .icon
+                .set_from_icon_name(Some(&self.data.icon), gtk::IconSize::Dnd);
+        }
 
-		if data.name != self.data.name {
-			self.data.name = data.name.clone();
-			self.rebuild_widgets();
-		}
+        if data.name != self.data.name {
+            self.data.name = data.name.clone();
+            self.rebuild_widgets();
+        }
 
-		if data.description != self.data.description {
-			self.data.description = data.description.clone();
-			self.widgets.label.set_label(&self.data.description);
-			self.widgets.app_button.set_tooltip_text(Some(&self.data.description));
-		}
+        if data.description != self.data.description {
+            self.data.description = data.description.clone();
+            self.widgets.label.set_label(&self.data.description);
+            self.widgets
+                .app_button
+                .set_tooltip_text(Some(&self.data.description));
+        }
 
-		if volume_changed || data.muted != self.data.muted {
-			self.data.volume = data.volume;
-			self.data.muted = data.muted;
-			self.update_widgets();
+        if volume_changed || data.muted != self.data.muted {
+            self.data.volume = data.volume;
+            self.data.muted = data.muted;
+            self.update_widgets();
 
-			let status_vol = self.data.volume.max().0;
+            let status_vol = self.data.volume.max().0;
 
-			self.widgets.status_icon.set_from_icon_name(Some(OUTPUT_ICONS[
-				if self.data.muted { 0 } else if status_vol >= MAX_NATURAL_VOL { 3 }
-				else if status_vol >= MAX_NATURAL_VOL / 2 { 2 } else { 1 }]), gtk::IconSize::Button);
+            self.widgets.status_icon.set_from_icon_name(
+                Some(
+                    OUTPUT_ICONS[if self.data.muted {
+                        0
+                    } else if status_vol >= MAX_NATURAL_VOL {
+                        3
+                    } else if status_vol >= MAX_NATURAL_VOL / 2 {
+                        2
+                    } else {
+                        1
+                    }],
+                ),
+                gtk::IconSize::Button,
+            );
 
-			let mut vol_scaled = ((status_vol as f64) / MAX_NATURAL_VOL as f64 * 100.0).round() as u8;
-			if vol_scaled > 150 { vol_scaled = 150 }
+            let mut vol_scaled =
+                ((status_vol as f64) / MAX_NATURAL_VOL as f64 * 100.0).round() as u8;
+            if vol_scaled > 150 {
+                vol_scaled = 150
+            }
 
-			let mut string = vol_scaled.to_string();
-			string.push_str("%");
-			self.widgets.status.set_label(&string);
+            let mut string = vol_scaled.to_string();
+            string.push_str("%");
+            self.widgets.status.set_label(&string);
 
-			let status_ctx = self.widgets.status.get_style_context();
-			if self.data.muted { status_ctx.add_class("muted") }
-			else { status_ctx.remove_class("muted") }
-		}
-	}
+            let status_ctx = self.widgets.status.get_style_context();
+            if self.data.muted {
+                status_ctx.add_class("muted")
+            } else {
+                status_ctx.remove_class("muted")
+            }
+        }
+    }
 
-	fn set_peak(&mut self, peak: Option<u32>) {
-		if self.peak != peak {
-			self.peak = peak;
+    fn set_peak(&mut self, peak: Option<u32>) {
+        if self.peak != peak {
+            self.peak = peak;
 
-			if self.peak.is_some() {
-				for (i, s) in self.widgets.scales_inner.get_children().iter().enumerate() {
-					let s = s.clone().downcast::<gtk::Scale>().expect("Scales box has non-scale children.");
-					let peak_scaled = self.peak.unwrap() as f64 * (self.data.volume.get()[i].0 as f64 / MAX_SCALE_VOL as f64);
-					s.set_fill_level(peak_scaled as f64);
-					s.set_show_fill_level(!self.data.muted && peak_scaled > 0.5);
-					s.get_style_context().add_class("visualizer");
-				}
-			}
-			else {
-				for s in &self.widgets.scales_inner.get_children() {
-					let s = s.clone().downcast::<gtk::Scale>().expect("Scales box has non-scale children.");
-					s.set_show_fill_level(false);
-					s.get_style_context().remove_class("visualizer");
-				}
-			}
-		}
-	}
+            if self.peak.is_some() {
+                for (i, s) in self.widgets.scales_inner.get_children().iter().enumerate() {
+                    let s = s
+                        .clone()
+                        .downcast::<gtk::Scale>()
+                        .expect("Scales box has non-scale children.");
+                    let peak_scaled = self.peak.unwrap() as f64
+                        * (self.data.volume.get()[i].0 as f64 / MAX_SCALE_VOL as f64);
+                    s.set_fill_level(peak_scaled as f64);
+                    s.set_show_fill_level(!self.data.muted && peak_scaled > 0.5);
+                    s.get_style_context().add_class("visualizer");
+                }
+            } else {
+                for s in &self.widgets.scales_inner.get_children() {
+                    let s = s
+                        .clone()
+                        .downcast::<gtk::Scale>()
+                        .expect("Scales box has non-scale children.");
+                    s.set_show_fill_level(false);
+                    s.get_style_context().remove_class("visualizer");
+                }
+            }
+        }
+    }
 }

--- a/src/meter/source_meter.rs
+++ b/src/meter/source_meter.rs
@@ -2,15 +2,14 @@
  * A specialized meter for representing sources.
  */
 
+use glib::translate::{FromGlib, ToGlib};
 use gtk;
 use gtk::prelude::*;
-use glib::translate::{ ToGlib, FromGlib };
 
+use super::meter::{Meter, MeterData, MeterWidgets};
+use super::meter::{INPUT_ICONS, MAX_NATURAL_VOL, MAX_SCALE_VOL};
 use crate::pulse::Pulse;
 use crate::shared::Shared;
-use super::meter::{ Meter, MeterWidgets, MeterData };
-use super::meter::{ MAX_NATURAL_VOL, MAX_SCALE_VOL, INPUT_ICONS };
-
 
 /**
  * A meter widget representing a source.
@@ -18,238 +17,292 @@ use super::meter::{ MAX_NATURAL_VOL, MAX_SCALE_VOL, INPUT_ICONS };
  */
 
 pub struct SourceMeter {
-	pub widget: gtk::Box,
+    pub widget: gtk::Box,
 
-	data: MeterData,
-	widgets: MeterWidgets,
-	pulse: Shared<Pulse>,
+    data: MeterData,
+    widgets: MeterWidgets,
+    pulse: Shared<Pulse>,
 
-	split: bool,
-	peak: Option<u32>,
+    split: bool,
+    peak: Option<u32>,
 
-	l_id: Option<glib::signal::SignalHandlerId>,
-	s_id: Option<glib::signal::SignalHandlerId>,
+    l_id: Option<glib::signal::SignalHandlerId>,
+    s_id: Option<glib::signal::SignalHandlerId>,
 }
 
 impl SourceMeter {
+    /**
+     * Creates a new SourceMeter.
+     */
 
-	/**
-	 * Creates a new SourceMeter.
-	 */
+    pub fn new(pulse: Shared<Pulse>) -> Self {
+        let widgets = Meter::build_meter();
 
-	pub fn new(pulse: Shared<Pulse>) -> Self {
-		let widgets = Meter::build_meter();
+        Self {
+            widget: widgets.root.clone(),
 
-		Self {
-			widget: widgets.root.clone(),
-			
-			pulse,
-			widgets,
-			data: MeterData::default(),
+            pulse,
+            widgets,
+            data: MeterData::default(),
 
-			split: false, peak: None, l_id: None, s_id: None
-		}
-	}
+            split: false,
+            peak: None,
+            l_id: None,
+            s_id: None,
+        }
+    }
 
+    /**
+     * Rebuilds widgets that are dependent on the Pulse instance or the source index.
+     * Reconnects the widgets to the Pulse instance, if one is provided.
+     */
 
-	/**
-	 * Rebuilds widgets that are dependent on the Pulse instance or the source index.
-	 * Reconnects the widgets to the Pulse instance, if one is provided.
-	 */
+    fn rebuild_widgets(&mut self) {
+        let scales = Meter::build_scales(&self.pulse, &self.data, self.split);
+        self.widgets.scales_outer.remove(&self.widgets.scales_inner);
+        self.widgets
+            .scales_outer
+            .pack_start(&scales, true, false, 0);
+        self.widgets.scales_inner = scales;
+        self.update_widgets();
 
-	fn rebuild_widgets(&mut self) {
-		let scales = Meter::build_scales(&self.pulse, &self.data, self.split);
-		self.widgets.scales_outer.remove(&self.widgets.scales_inner);
-		self.widgets.scales_outer.pack_start(&scales, true, false, 0);
-		self.widgets.scales_inner = scales;
-		self.update_widgets();
+        let t = self.data.t;
+        let index = self.data.index;
+        let pulse = self.pulse.clone();
 
-		let t 		= self.data.t;
-		let index = self.data.index;
-		let pulse = self.pulse.clone();
+        if self.s_id.is_some() {
+            self.widgets
+                .status
+                .disconnect(glib::signal::SignalHandlerId::from_glib(
+                    self.s_id.as_ref().unwrap().to_glib(),
+                ))
+        }
+        self.s_id = Some(self.widgets.status.connect_clicked(move |status| {
+            pulse
+                .borrow_mut()
+                .set_muted(t, index, !status.get_style_context().has_class("muted"));
+        }));
 
-		if self.s_id.is_some() { self.widgets.status.disconnect(
-			glib::signal::SignalHandlerId::from_glib(self.s_id.as_ref().unwrap().to_glib())) }
-		self.s_id = Some(self.widgets.status.connect_clicked(move |status| {
-			pulse.borrow_mut().set_muted(t, index,
-				!status.get_style_context().has_class("muted"));
-		}));
+        let pulse = self.pulse.clone();
+        let index = self.data.index;
 
-		let pulse = self.pulse.clone();
-		let index = self.data.index;
+        if self.l_id.is_some() {
+            self.widgets
+                .app_button
+                .disconnect(glib::signal::SignalHandlerId::from_glib(
+                    self.l_id.as_ref().unwrap().to_glib(),
+                ))
+        }
+        self.l_id = Some(self.widgets.app_button.connect_clicked(move |trigger| {
+            SourceMeter::show_popup(&trigger, &pulse, index);
+        }));
+    }
 
-		if self.l_id.is_some() { self.widgets.app_button.disconnect(
-			glib::signal::SignalHandlerId::from_glib(self.l_id.as_ref().unwrap().to_glib())) }
-		self.l_id = Some(self.widgets.app_button.connect_clicked(move |trigger| {
-			SourceMeter::show_popup(&trigger, &pulse, index);
-		}));
-	}
+    /**
+     * Updates each scale widget to reflect the current volume level.
+     */
 
+    fn update_widgets(&mut self) {
+        for (i, v) in self.data.volume.get().iter().enumerate() {
+            if let Some(scale) = self.widgets.scales_inner.get_children().get(i) {
+                let scale = scale
+                    .clone()
+                    .downcast::<gtk::Scale>()
+                    .expect("Scales box has non-scale children.");
+                scale.set_sensitive(!self.data.muted);
+                scale.set_value(v.0 as f64);
+            }
+        }
+    }
 
-	/**
-	 * Updates each scale widget to reflect the current volume level.
-	 */
+    /**
+     * Shows a popup menu on the top button, with items to set
+     * the Sink as default, and change the visible source.
+     */
 
-	fn update_widgets(&mut self) {
-		for (i, v) in self.data.volume.get().iter().enumerate() {
-			if let Some(scale) = self.widgets.scales_inner.get_children().get(i) {
-				let scale = scale.clone().downcast::<gtk::Scale>().expect("Scales box has non-scale children.");
-				scale.set_sensitive(!self.data.muted);
-				scale.set_value(v.0 as f64);
-			}
-		}
-	}
+    fn show_popup(trigger: &gtk::Button, pulse_shr: &Shared<Pulse>, index: u32) {
+        let pulse = pulse_shr.borrow_mut();
+        let root = gtk::PopoverMenu::new();
+        root.set_border_width(6);
 
+        let menu = gtk::Box::new(gtk::Orientation::Vertical, 0);
+        menu.set_size_request(132, -1);
+        root.add(&menu);
 
-	/**
-	 * Shows a popup menu on the top button, with items to set
-	 * the Sink as default, and change the visible source.
-	 */
+        // let split_channels = gtk::ModelButton::new();
+        // split_channels.set_property_text(Some("Split Channels"));
+        // split_channels.set_action_name(Some("app.split_channels"));
+        // menu.add(&split_channels);
 
-	fn show_popup(trigger: &gtk::Button, pulse_shr: &Shared<Pulse>, index: u32) {
-		let pulse = pulse_shr.borrow_mut();
-		let root = gtk::PopoverMenu::new();
-		root.set_border_width(6);
+        let set_default = gtk::ModelButton::new();
+        set_default.set_property_role(gtk::ButtonRole::Check);
+        set_default.set_property_text(Some("Set as Default"));
+        set_default.set_property_active(pulse.default_source == index);
+        set_default.set_sensitive(pulse.default_source != index);
 
-		let menu = gtk::Box::new(gtk::Orientation::Vertical, 0);
-		menu.set_size_request(132, -1);
-		root.add(&menu);
-		
-		// let split_channels = gtk::ModelButton::new();
-		// split_channels.set_property_text(Some("Split Channels"));
-		// split_channels.set_action_name(Some("app.split_channels"));
-		// menu.add(&split_channels);
+        let pulse_clone = pulse_shr.clone();
+        set_default.connect_clicked(move |set_default| {
+            pulse_clone.borrow_mut().set_default_source(index);
+            set_default.set_property_active(true);
+            set_default.set_sensitive(false);
+        });
+        menu.add(&set_default);
 
-		let set_default = gtk::ModelButton::new();
-		set_default.set_property_role(gtk::ButtonRole::Check);
-		set_default.set_property_text(Some("Set as Default"));
-		set_default.set_property_active(pulse.default_source == index);
-		set_default.set_sensitive(pulse.default_source != index);
-			
-		let pulse_clone = pulse_shr.clone();
-		set_default.connect_clicked(move |set_default| {
-			pulse_clone.borrow_mut().set_default_source(index);
-			set_default.set_property_active(true);
-			set_default.set_sensitive(false);
-		});
-		menu.add(&set_default);
+        if pulse.sources.len() >= 2 {
+            menu.pack_start(&gtk::SeparatorMenuItem::new(), false, false, 3);
 
-		if pulse.sources.len() >= 2 {
-			menu.pack_start(&gtk::SeparatorMenuItem::new(), false, false, 3);
+            let label = gtk::Label::new(Some("Visible Input"));
+            label.set_sensitive(false);
+            menu.pack_start(&label, true, true, 3);
 
-			let label = gtk::Label::new(Some("Visible Input"));
-			label.set_sensitive(false);
-			menu.pack_start(&label, true, true, 3);
-			
-			for (i, v) in &pulse.sources {
-				let button = gtk::ModelButton::new();
-				button.set_property_role(gtk::ButtonRole::Radio);
-				button.set_property_active(v.data.index == index);
-				let button_label = gtk::Label::new(Some(&v.data.description));
-				button_label.set_ellipsize(pango::EllipsizeMode::End);
-				button_label.set_max_width_chars(18);
-				button.get_child().unwrap().downcast::<gtk::Box>().unwrap().add(&button_label);
+            for (i, v) in &pulse.sources {
+                let button = gtk::ModelButton::new();
+                button.set_property_role(gtk::ButtonRole::Radio);
+                button.set_property_active(v.data.index == index);
+                let button_label = gtk::Label::new(Some(&v.data.description));
+                button_label.set_ellipsize(pango::EllipsizeMode::End);
+                button_label.set_max_width_chars(18);
+                button
+                    .get_child()
+                    .unwrap()
+                    .downcast::<gtk::Box>()
+                    .unwrap()
+                    .add(&button_label);
 
-				let i = *i;
-				let root = root.clone();
-				let pulse_clone = pulse_shr.clone();
-				button.connect_clicked(move |_| {
-					pulse_clone.borrow_mut().set_active_source(i);
-					root.popdown();
-				});
-				
-				menu.add(&button);
-			}
-		}
+                let i = *i;
+                let root = root.clone();
+                let pulse_clone = pulse_shr.clone();
+                button.connect_clicked(move |_| {
+                    pulse_clone.borrow_mut().set_active_source(i);
+                    root.popdown();
+                });
 
-		for child in &root.get_children() { child.show_all(); }
-		root.set_relative_to(Some(trigger));
-		root.popup();
-	}
+                menu.add(&button);
+            }
+        }
+
+        for child in &root.get_children() {
+            child.show_all();
+        }
+        root.set_relative_to(Some(trigger));
+        root.popup();
+    }
 }
 
 impl Meter for SourceMeter {
-	fn get_index(&self) -> u32 {
-		self.data.index
-	}
-	
-	fn split_channels(&mut self, split: bool) {
-		if self.split == split { return }
-		self.split = split;
-		self.rebuild_widgets();
-	}
+    fn get_index(&self) -> u32 {
+        self.data.index
+    }
 
-	fn set_data(&mut self, data: &MeterData) {
-		let volume_old = self.data.volume;
-		let volume_changed = data.volume != volume_old;
+    fn split_channels(&mut self, split: bool) {
+        if self.split == split {
+            return;
+        }
+        self.split = split;
+        self.rebuild_widgets();
+    }
 
-		if data.t != self.data.t || data.index != self.data.index || data.volume.len() != self.data.volume.len() {
-			self.data.t = data.t;
-			self.data.volume = data.volume;
-			self.data.index = data.index;
-			self.rebuild_widgets();
-		}
+    fn set_data(&mut self, data: &MeterData) {
+        let volume_old = self.data.volume;
+        let volume_changed = data.volume != volume_old;
 
-		if data.icon != self.data.icon {
-			self.data.icon = data.icon.clone();
-			self.widgets.icon.set_from_icon_name(Some(&self.data.icon), gtk::IconSize::Dnd);
-		}
+        if data.t != self.data.t
+            || data.index != self.data.index
+            || data.volume.len() != self.data.volume.len()
+        {
+            self.data.t = data.t;
+            self.data.volume = data.volume;
+            self.data.index = data.index;
+            self.rebuild_widgets();
+        }
 
-		if data.name != self.data.name {
-			self.data.name = data.name.clone();
-			self.rebuild_widgets();
-		}
+        if data.icon != self.data.icon {
+            self.data.icon = data.icon.clone();
+            self.widgets
+                .icon
+                .set_from_icon_name(Some(&self.data.icon), gtk::IconSize::Dnd);
+        }
 
-		if data.description != self.data.description {
-			self.data.description = data.description.clone();
-			self.widgets.label.set_label(&self.data.description);
-			self.widgets.app_button.set_tooltip_text(Some(&self.data.description));
-		}
+        if data.name != self.data.name {
+            self.data.name = data.name.clone();
+            self.rebuild_widgets();
+        }
 
-		if volume_changed || data.muted != self.data.muted {
-			self.data.volume = data.volume;
-			self.data.muted = data.muted;
-			self.update_widgets();
+        if data.description != self.data.description {
+            self.data.description = data.description.clone();
+            self.widgets.label.set_label(&self.data.description);
+            self.widgets
+                .app_button
+                .set_tooltip_text(Some(&self.data.description));
+        }
 
-			let status_vol = self.data.volume.max().0;
+        if volume_changed || data.muted != self.data.muted {
+            self.data.volume = data.volume;
+            self.data.muted = data.muted;
+            self.update_widgets();
 
-			self.widgets.status_icon.set_from_icon_name(Some(INPUT_ICONS[
-				if self.data.muted { 0 } else if status_vol >= MAX_NATURAL_VOL { 3 }
-				else if status_vol >= MAX_NATURAL_VOL / 2 { 2 } else { 1 }]), gtk::IconSize::Button);
+            let status_vol = self.data.volume.max().0;
 
-			let mut vol_scaled = ((status_vol as f64) / MAX_NATURAL_VOL as f64 * 100.0).round() as u8;
-			if vol_scaled > 150 { vol_scaled = 150 }
+            self.widgets.status_icon.set_from_icon_name(
+                Some(
+                    INPUT_ICONS[if self.data.muted {
+                        0
+                    } else if status_vol >= MAX_NATURAL_VOL {
+                        3
+                    } else if status_vol >= MAX_NATURAL_VOL / 2 {
+                        2
+                    } else {
+                        1
+                    }],
+                ),
+                gtk::IconSize::Button,
+            );
 
-			let mut string = vol_scaled.to_string();
-			string.push_str("%");
-			self.widgets.status.set_label(&string);
+            let mut vol_scaled =
+                ((status_vol as f64) / MAX_NATURAL_VOL as f64 * 100.0).round() as u8;
+            if vol_scaled > 150 {
+                vol_scaled = 150
+            }
 
-			let status_ctx = self.widgets.status.get_style_context();
-			if self.data.muted { status_ctx.add_class("muted") }
-			else { status_ctx.remove_class("muted") }
-		}
-	}
+            let mut string = vol_scaled.to_string();
+            string.push_str("%");
+            self.widgets.status.set_label(&string);
 
-	fn set_peak(&mut self, peak: Option<u32>) {
-		if self.peak != peak {
-			self.peak = peak;
+            let status_ctx = self.widgets.status.get_style_context();
+            if self.data.muted {
+                status_ctx.add_class("muted")
+            } else {
+                status_ctx.remove_class("muted")
+            }
+        }
+    }
 
-			if self.peak.is_some() {
-				for (i, s) in self.widgets.scales_inner.get_children().iter().enumerate() {
-					let s = s.clone().downcast::<gtk::Scale>().expect("Scales box has non-scale children.");
-					let peak_scaled = self.peak.unwrap() as f64 * (self.data.volume.get()[i].0 as f64 / MAX_SCALE_VOL as f64);
-					s.set_fill_level(peak_scaled as f64);
-					s.set_show_fill_level(!self.data.muted && peak_scaled > 0.5);
-					s.get_style_context().add_class("visualizer");
-				}
-			}
-			else {
-				for s in &self.widgets.scales_inner.get_children() {
-					let s = s.clone().downcast::<gtk::Scale>().expect("Scales box has non-scale children.");
-					s.set_show_fill_level(false);
-					s.get_style_context().remove_class("visualizer");
-				}
-			}
-		}
-	}
+    fn set_peak(&mut self, peak: Option<u32>) {
+        if self.peak != peak {
+            self.peak = peak;
+
+            if self.peak.is_some() {
+                for (i, s) in self.widgets.scales_inner.get_children().iter().enumerate() {
+                    let s = s
+                        .clone()
+                        .downcast::<gtk::Scale>()
+                        .expect("Scales box has non-scale children.");
+                    let peak_scaled = self.peak.unwrap() as f64
+                        * (self.data.volume.get()[i].0 as f64 / MAX_SCALE_VOL as f64);
+                    s.set_fill_level(peak_scaled as f64);
+                    s.set_show_fill_level(!self.data.muted && peak_scaled > 0.5);
+                    s.get_style_context().add_class("visualizer");
+                }
+            } else {
+                for s in &self.widgets.scales_inner.get_children() {
+                    let s = s
+                        .clone()
+                        .downcast::<gtk::Scale>()
+                        .expect("Scales box has non-scale children.");
+                    s.set_show_fill_level(false);
+                    s.get_style_context().remove_class("visualizer");
+                }
+            }
+        }
+    }
 }

--- a/src/pulse.rs
+++ b/src/pulse.rs
@@ -3,26 +3,27 @@
  * Monitors the pulse server for updates, and also exposes methods to request changes.
  */
 
-use slice_as_array::{ slice_as_array, slice_as_array_transmute };
+use slice_as_array::{slice_as_array, slice_as_array_transmute};
 
-use libpulse::def::BufferAttr;
 use libpulse::callbacks::ListResult;
-use libpulse::volume::ChannelVolumes;
-use libpulse::sample::{ Spec, Format };
+use libpulse::context::introspect::{
+    CardInfo, ServerInfo, SinkInfo, SinkInputInfo, SourceInfo, SourceOutputInfo,
+};
+use libpulse::context::subscribe::{Facility, InterestMaskSet, Operation};
+use libpulse::context::{Context, FlagSet as CtxFlagSet, State as ContextState};
+use libpulse::def::BufferAttr;
 use libpulse::mainloop::threaded::Mainloop;
-use libpulse::proplist::{ Proplist, properties };
-use libpulse::stream::{ Stream, FlagSet as StreamFlagSet, PeekResult };
-use libpulse::context::subscribe::{ InterestMaskSet, Facility, Operation };
-use libpulse::context::{ Context, FlagSet as CtxFlagSet, State as ContextState };
-use libpulse::context::introspect::{ ServerInfo, SourceInfo, SinkInfo, SinkInputInfo, SourceOutputInfo, CardInfo };
+use libpulse::proplist::{properties, Proplist};
+use libpulse::sample::{Format, Spec};
+use libpulse::stream::{FlagSet as StreamFlagSet, PeekResult, Stream};
+use libpulse::volume::ChannelVolumes;
 
 use std::collections::HashMap;
-use std::sync::mpsc::{ channel, Sender, Receiver };
+use std::sync::mpsc::{channel, Receiver, Sender};
 
-use super::shared::Shared;
 use super::card::CardData;
 use super::meter::MeterData;
-
+use super::shared::Shared;
 
 /**
  * Represents a stream's underlying type.
@@ -30,13 +31,17 @@ use super::meter::MeterData;
 
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum StreamType {
-	Sink, SinkInput, Source, SourceOutput
+    Sink,
+    SinkInput,
+    Source,
+    SourceOutput,
 }
 
 impl Default for StreamType {
-	fn default() -> Self { StreamType::Sink }
+    fn default() -> Self {
+        StreamType::Sink
+    }
 }
-
 
 /**
  * The different message types that can be passed from the pulse
@@ -45,14 +50,13 @@ impl Default for StreamType {
  */
 
 enum TxMessage {
-	Default(String, String),
-	StreamUpdate(StreamType, TxStreamData),
-	StreamRemove(StreamType, u32),
-	CardUpdate(CardData),
-	CardRemove(u32),
-	Peak(StreamType, u32, u32)
+    Default(String, String),
+    StreamUpdate(StreamType, TxStreamData),
+    StreamRemove(StreamType, u32),
+    CardUpdate(CardData),
+    CardRemove(u32),
+    Peak(StreamType, u32, u32),
 }
-
 
 /**
  * Transferrable information pretaining to a stream.
@@ -60,10 +64,9 @@ enum TxMessage {
 
 #[derive(Debug)]
 pub struct TxStreamData {
-	pub data: MeterData,
-	pub monitor_index: u32,
+    pub data: MeterData,
+    pub monitor_index: u32,
 }
-
 
 /**
  * Stored representation of a pulse stream.
@@ -72,17 +75,18 @@ pub struct TxStreamData {
  */
 
 pub struct StreamData {
-	pub data: MeterData,
+    pub data: MeterData,
 
-	pub peak: u32,
-	pub monitor_index: u32,
-	pub monitor: Shared<Stream>
+    pub peak: u32,
+    pub monitor_index: u32,
+    pub monitor: Shared<Stream>,
 }
 
-
 /** Container for mspc channel sender & receiver. */
-struct Channel<T> { tx: Sender<T>, rx: Receiver<T> }
-
+struct Channel<T> {
+    tx: Sender<T>,
+    rx: Receiver<T>,
+}
 
 /**
  * The main controller for all pulse server interactions.
@@ -91,636 +95,768 @@ struct Channel<T> { tx: Sender<T>, rx: Receiver<T> }
  */
 
 pub struct Pulse {
-	mainloop: Shared<Mainloop>,
-	context: Shared<Context>,
-	channel: Channel<TxMessage>,
+    mainloop: Shared<Mainloop>,
+    context: Shared<Context>,
+    channel: Channel<TxMessage>,
 
-	pub default_sink: u32,
-	pub default_source: u32,
-	pub active_sink: u32,
-	pub active_source: u32,
+    pub default_sink: u32,
+    pub default_source: u32,
+    pub active_sink: u32,
+    pub active_source: u32,
 
-	pub sinks: HashMap<u32, StreamData>,
-	pub sink_inputs: HashMap<u32, StreamData>,
-	pub sources: HashMap<u32, StreamData>,
-	pub source_outputs: HashMap<u32, StreamData>,
-	pub cards: HashMap<u32, CardData>,
+    pub sinks: HashMap<u32, StreamData>,
+    pub sink_inputs: HashMap<u32, StreamData>,
+    pub sources: HashMap<u32, StreamData>,
+    pub source_outputs: HashMap<u32, StreamData>,
+    pub cards: HashMap<u32, CardData>,
 }
 
 impl Pulse {
-
-	/**
-	 * Creates a new pulse controller, configuring (but not initializing) the pulse connection.
-	 */
-
-	pub fn new() -> Self {
-		let mut proplist = Proplist::new().unwrap();
-		proplist.set_str(properties::APPLICATION_NAME, "Myxer").unwrap();
-
-		let mainloop = Shared::new(Mainloop::new().expect("Failed to initialize pulse mainloop."));
-
-		let context = Shared::new(
-			Context::new_with_proplist(&*mainloop.borrow(), "Myxer Context", &proplist)
-			.expect("Failed to initialize pulse context."));
-
-		let ( tx, rx ) = channel::<TxMessage>();
-
-		Pulse {
-			mainloop, context,
-			channel: Channel { tx, rx },
-
-			default_sink: u32::MAX,
-			default_source: u32::MAX,
-			active_sink: u32::MAX,
-			active_source: u32::MAX,
-
-			sinks: HashMap::new(),
-			sink_inputs: HashMap::new(),
-			sources: HashMap::new(),
-			source_outputs: HashMap::new(),
-			cards: HashMap::new()
-		}
-	}
-
-
-	/**
-	 * Initiates a connection to pulse. Blocks until success, panics on failure.
-	 * TODO: Graceful error handling, with debug message.
-	 * TODO: Try to see if there's a way to avoid using unsafe? It's in the docs...  but...?
-	 */
-
-	pub fn connect(&mut self) {
-		let mut mainloop = self.mainloop.borrow_mut();
-		let mut ctx = self.context.borrow_mut();
-
-		let mainloop_shr_ref = self.mainloop.clone();
-		let ctx_shr_ref = self.context.clone();
-
-		ctx.set_state_callback(Some(Box::new(move || {
-			match unsafe { (*ctx_shr_ref.as_ptr()).get_state() } {
-				ContextState::Ready |
-				ContextState::Failed |
-				ContextState::Terminated =>
-					unsafe { (*mainloop_shr_ref.as_ptr()).signal(false); },
-				_ => {},
-			}
-		})));
-
-		ctx.connect(None, CtxFlagSet::NOFLAGS, None)
-			.expect("Failed to connect to the pulse server.");
-
-		mainloop.lock();
-		mainloop.start().expect("Failed to start pulse mainloop.");
-
-		loop {
-			match ctx.get_state() {
-				ContextState::Ready => {
-					ctx.set_state_callback(None);
-					mainloop.unlock();
-					break;
-				},
-				ContextState::Failed |
-				ContextState::Terminated => {
-					eprintln!("Context state failed/terminated, quitting...");
-					mainloop.unlock();
-					mainloop.stop();
-					panic!("Pulse session terminated.");
-				},
-				_ => { mainloop.wait(); },
-			}
-		}
-
-		drop(ctx);
-		drop(mainloop);
-		self.subscribe();
-	}
-
-
-	/**
-	 * Asynchronously sets the default sink to the index provided.
-	 * This is sometimes described as the fallback device.
-	 *
-	 * * `sink` - The sink index to set as the default.
-	 */
-
-	pub fn set_default_sink(&self, sink: u32) {
-		if let Some(sink) = self.sinks.get(&sink) {
-			let mut mainloop = self.mainloop.borrow_mut();
-			mainloop.lock();
-			self.context.borrow_mut().set_default_sink(&sink.data.name, |_|());
-			mainloop.unlock();
-		}
-	}
-
-
-	/**
-	 * Asynchronously sets the default source to the index provided.
-	 * This is sometimes described as the fallback device.
-	 *
-	 * * `source` - The source index to set as the default.
-	 */
-
-	pub fn set_default_source(&self, source: u32) {
-		if let Some(source) = self.sources.get(&source) {
-			let mut mainloop = self.mainloop.borrow_mut();
-			mainloop.lock();
-			self.context.borrow_mut().set_default_source(&source.data.name, |_|());
-			mainloop.unlock();
-		}
-	}
-
-
-	/**
-	 * Sets the 'active' sink to the index provided.
-	 * This is the sink that is currently displayed on the interface.
-	 *
-	 * * `sink` - The sink index to set as active.
-	 */
-
-	pub fn set_active_sink(&mut self, sink: u32) {
-		self.active_sink = sink;
-	}
-
-
-	/**
-	 * Sets the 'active' source to the index provided.
-	 * This is the source that is currently displayed on the interface.
-	 *
-	 * * `source` - The source to set as active.
-	 */
-
-	pub fn set_active_source(&mut self, source: u32) {
-		self.active_source = source;
-	}
-
-
-	/**
-	 * Sets the volume of the stream to the volumes specified.
-	 * This operation is asynchronous, so changes will not be reflected immediately.
-	 *
-	 * * `t`       - The type of stream to set the volume of.
-	 * * `index`   - The index of the stream to set the volume of.
-	 * * `volumes` - The desired volumes to set the channels of the stream to.
-	 */
-
-	pub fn set_volume(&self, t: StreamType, index: u32, volumes: ChannelVolumes) {
-		let mut introspect = self.context.borrow().introspect();
-		let mut mainloop = self.mainloop.borrow_mut();
-		mainloop.lock();
-
-		match t {
-			StreamType::Sink => drop(introspect.set_sink_volume_by_index(index, &volumes, None)),
-			StreamType::SinkInput => drop(introspect.set_sink_input_volume(index, &volumes, None)),
-			StreamType::Source => drop(introspect.set_source_volume_by_index(index, &volumes, None)),
-			StreamType::SourceOutput => drop(introspect.set_source_output_volume(index, &volumes, None))
-		};
-
-		mainloop.unlock();
-	}
-
-
-	/**
-	 * Mutes or unmutes a stream.
-	 * This operation is asynchronous, so changes will not be reflected immediately.
-	 *
-	 * * `t`     - The type of stream to update.
-	 * * `index` - The index of the stream to update.
-	 * * `mute`  - Whether the stream should be muted or not.
-	 */
-
-	pub fn set_muted(&self, t: StreamType, index: u32, mute: bool) {
-		let mut introspect = self.context.borrow().introspect();
-		let mut mainloop = self.mainloop.borrow_mut();
-		mainloop.lock();
-
-		match t {
-			StreamType::Sink => drop(introspect.set_sink_mute_by_index(index, mute, None)),
-			StreamType::SinkInput => drop(introspect.set_sink_input_mute(index, mute, None)),
-			StreamType::Source => drop(introspect.set_source_mute_by_index(index, mute, None)),
-			StreamType::SourceOutput => drop(introspect.set_source_output_mute(index, mute, None))
-		};
-
-		mainloop.unlock();
-	}
-
-
-	/**
-	 * Set's a sound card's profile.
-	 * This effects how the card behaves, and how the system can utilize it.
-	 *
-	 * * `index`   - The card index to update.
-	 * * `profile` - The profile name to update the card to.
-	 */
-	 
-	pub fn set_card_profile(&self, index: u32, profile: &str) {
-		let mut introspect = self.context.borrow().introspect();
-		let mut mainloop = self.mainloop.borrow_mut();
-		mainloop.lock();
-		introspect.set_card_profile_by_index(index, profile, None);
-		mainloop.unlock();
-	}
-
-
-	/**
-	 * Binds listeners to server events, and triggers an
-	 * initial sweep to populate the internal stores.
-	 * Called by connect(), separated for readability.
-	 */
-
-	fn subscribe(&mut self) {
-		/** Updates the client when the server information changes. */
-		fn tx_server(tx: &Sender<TxMessage>, item: &ServerInfo<'_>) {
-			tx.send(TxMessage::Default(item.default_sink_name.clone().unwrap().into_owned(),
-				item.default_source_name.clone().unwrap().into_owned())).unwrap();
-		};
-
-		/** Updates the client when a sink changes. */
-		fn tx_sink(tx: &Sender<TxMessage>, result: ListResult<&SinkInfo<'_>>) {
-			if let ListResult::Item(item) = result {
-				tx.send(TxMessage::StreamUpdate(StreamType::Sink, TxStreamData {
-					data: MeterData {
-						t: StreamType::Sink,
-						index: item.index,
-						icon: "multimedia-volume-control".to_owned(),
-						name: item.name.clone().unwrap().into_owned(),
-						description: item.description.clone().unwrap().into_owned(),
-						volume: item.volume,
-						muted: item.mute
-					},
-					monitor_index: item.monitor_source
-				})).unwrap();
-			};
-		};
-
-		/** Updates the client when a sink input changes. */
-		fn tx_sink_input(tx: &Sender<TxMessage>, result: ListResult<&SinkInputInfo<'_>>) {
-			if let ListResult::Item(item) = result {
-				tx.send(TxMessage::StreamUpdate(StreamType::SinkInput, TxStreamData {
-					data: MeterData {
-						t: StreamType::SinkInput,
-						index: item.index,
-						icon: item.proplist.get_str("application.icon_name").unwrap_or_else(|| "audio-card".to_owned()),
-						name: item.name.clone().unwrap().into_owned(),
-						description: item.proplist.get_str("application.name").unwrap_or("".to_owned()),
-						volume: item.volume,
-						muted: item.mute
-					},
-					monitor_index: item.sink
-				})).unwrap();
-			};
-		};
-
-		/** Updates the client when a source changes. */
-		fn tx_source(tx: &Sender<TxMessage>, result: ListResult<&SourceInfo<'_>>) {
-			if let ListResult::Item(item) = result {
-				let name = item.name.clone().unwrap().into_owned();
-				if name.ends_with(".monitor") { return; }
-				tx.send(TxMessage::StreamUpdate(StreamType::Source, TxStreamData {
-					data: MeterData {
-						t: StreamType::Source,
-						index: item.index,
-						icon: "audio-input-microphone".to_owned(),
-						name: item.name.clone().unwrap().into_owned(),
-						description: item.description.clone().unwrap().into_owned(),
-						volume: item.volume,
-						muted: item.mute
-					},
-					monitor_index: item.index
-				})).unwrap();
-			};
-		};
-
-		/** Updates the client when a source output changes. */
-		fn tx_source_output(tx: &Sender<TxMessage>, result: ListResult<&SourceOutputInfo<'_>>) {
-			if let ListResult::Item(item) = result {
-				let app_id = item.proplist.get_str("application.process.binary").unwrap_or("".to_owned()).to_lowercase();
-				if app_id.contains("pavucontrol") || app_id.contains("myxer") { return; }
-				tx.send(TxMessage::StreamUpdate(StreamType::SourceOutput, TxStreamData {
-					data: MeterData {
-						t: StreamType::SourceOutput,
-						index: item.index,
-						icon: item.proplist.get_str("application.icon_name").unwrap_or_else(|| "audio-card".to_owned()),
-						name: item.name.clone().unwrap().into_owned(),
-						description: item.proplist.get_str("application.name").unwrap_or("".to_owned()),
-						volume: item.volume,
-						muted: item.mute
-					},
-					monitor_index: item.source
-				})).unwrap();
-			};
-		};
-
-		/** Updates the client when a sound card changes. */
-		fn tx_card(tx: &Sender<TxMessage>, result: ListResult<&CardInfo<'_>>) {
-			if let ListResult::Item(item) = result {
-				tx.send(TxMessage::CardUpdate(CardData {
-					index: item.index,
-					name: item.proplist.get_str("device.description").unwrap_or("".to_owned()),
-					icon: item.proplist.get_str("device.icon_name").unwrap_or_else(|| "audio-card-pci".to_owned()),
-					profiles: item.profiles.iter().map(|p| (p.name.as_ref().unwrap().clone().into_owned(),
-						p.description.as_ref().unwrap().clone().into_owned())).collect(),
-					active_profile: item.active_profile.as_ref().unwrap().name.as_ref().unwrap().clone().into_owned()
-				})).unwrap();
-			}
-		}
-
-		let mut mainloop = self.mainloop.borrow_mut();
-		mainloop.lock();
-		let mut context = self.context.borrow_mut();
-		let introspect = context.introspect();
-
-		let tx = self.channel.tx.clone();
-		introspect.get_sink_info_list(move |res| tx_sink(&tx, res));
-		let tx = self.channel.tx.clone();
-		introspect.get_sink_input_info_list(move |res| tx_sink_input(&tx, res));
-		let tx = self.channel.tx.clone();
-		introspect.get_source_info_list(move |res| tx_source(&tx, res));
-		let tx = self.channel.tx.clone();
-		introspect.get_source_output_info_list(move |res| tx_source_output(&tx, res));
-		let tx = self.channel.tx.clone();
-		introspect.get_card_info_list(move |res| tx_card(&tx, res));
-		let tx = self.channel.tx.clone();
-		introspect.get_server_info(move |res| tx_server(&tx, res));
-		
-		let tx = self.channel.tx.clone();
-		context.subscribe(InterestMaskSet::SERVER | InterestMaskSet::SINK | InterestMaskSet::SINK_INPUT |
-			InterestMaskSet::SOURCE | InterestMaskSet::SOURCE_OUTPUT | InterestMaskSet::CARD, |_|());
-		context.set_subscribe_callback(Some(Box::new(move |fac, op, index| {
-			let tx = tx.clone();
-			let facility = fac.unwrap();
-			let operation = op.unwrap();
-
-			match facility {
-				Facility::Server => drop(introspect.get_server_info(move |res| tx_server(&tx, res))),
-				Facility::Sink => match operation {
-					Operation::Removed => tx.send(TxMessage::StreamRemove(StreamType::Sink, index)).unwrap(),
-					_ => drop(introspect.get_sink_info_by_index(index, move |res| tx_sink(&tx, res)))
-				},
-				Facility::SinkInput => match operation {
-					Operation::Removed => tx.send(TxMessage::StreamRemove(StreamType::SinkInput, index)).unwrap(),
-					_ => drop(introspect.get_sink_input_info(index, move |res| tx_sink_input(&tx, res)))
-				},
-				Facility::Source => match operation {
-					Operation::Removed => tx.send(TxMessage::StreamRemove(StreamType::Source, index)).unwrap(),
-					_ => drop(introspect.get_source_info_by_index(index, move |res| tx_source(&tx, res)))
-				},
-				Facility::SourceOutput => match operation {
-					Operation::Removed => tx.send(TxMessage::StreamRemove(StreamType::SourceOutput, index)).unwrap(),
-					_ => drop(introspect.get_source_output_info(index, move |res| tx_source_output(&tx, res)))
-				},
-				Facility::Card => match operation {
-					Operation::Removed => tx.send(TxMessage::CardRemove(index)).unwrap(),
-					_ => drop(introspect.get_card_info_by_index(index, move |res| tx_card(&tx, res)))
-				},
-				_ => ()
-			};
-		})));
-
-		mainloop.unlock();
-	}
-
-
-	/**
-	 * Handles queued messages from the pulse thread, updating the internal storage.
-	 * Returns a boolean indicating that a layout refresh is required.
-	 */
-
-	pub fn update(&mut self) -> bool {
-		let mut received = false;
-
-		loop {
-			let res = self.channel.rx.try_recv();
-			match res {
-				Ok(res) => {
-					received = true;
-					match res {
-						TxMessage::Default(sink, source) => self.update_default(sink, source),
-						TxMessage::StreamUpdate(t, data) => self.update_stream(t, &data),
-						TxMessage::StreamRemove(t, ind) => self.remove_stream(t, ind),
-						TxMessage::CardUpdate(data) => self.update_card(&data),
-						TxMessage::CardRemove(ind) => self.remove_card(ind),
-						TxMessage::Peak(t, ind, peak) => self.update_peak(t, ind, peak),
-					}
-				},
-				_ => break
-			}
-		}
-
-		received
-	}
-
-
-	/**
-	 * Closes the connection to the pulse server, and cleans up any dangling monitors.
-	 * After this operation, no other methods should be called, and the instance should be freed from memory.
-	 */
-
-	pub fn cleanup(&mut self) {
-		while let Some((i, _)) = self.sinks.iter().next() { let i = *i; self.remove_stream(StreamType::Sink, i) }
-		while let Some((i, _)) = self.sink_inputs.iter().next() { let i = *i; self.remove_stream(StreamType::SinkInput, i) }
-		while let Some((i, _)) = self.sources.iter().next() { let i = *i; self.remove_stream(StreamType::Source, i) }
-		while let Some((i, _)) = self.source_outputs.iter().next() { let i = *i; self.remove_stream(StreamType::SourceOutput, i) }
-		
-		let mut mainloop = self.mainloop.borrow_mut();
-		mainloop.stop();
-	}
-
-
-	/**
-	 * Updates the stored default sink and source to the ones identified.
-	 * This method is called by the update method, the names are provided by the pulse server.
-	 *
-	 * * `sink`   - The default sink.
-	 * * `source` - The default source.
-	 */
-
-	fn update_default(&mut self, sink: String, source: String) {
-		for (i, v) in &self.sinks {
-			if v.data.name == sink {
-				self.default_sink = *i;
-				self.active_sink = *i;
-				break;
-			}
-		}
-
-		for (i, v) in &self.sources {
-			if v.data.name == source {
-				self.default_source = *i;
-				self.active_source = *i;
-				break;
-			}
-		}
-	}
-
-
-	/**
-	 * Updates a stream in the store, or creates a new one and begins monitoring the peaks.
-	 * This method is called by the update method, the data is provided by the pulse server.
-	 *
-	 * * `t`      - The type of stream to update.
-	 * * `stream` - The new stream's data.
-	 */
-
-	fn update_stream(&mut self, t: StreamType, stream: &TxStreamData) {
-		let data = stream.data.clone();
-		let index = data.index;
-
-		let entry = match t {
-			StreamType::Sink => self.sinks.get_mut(&index),
-			StreamType::SinkInput => self.sink_inputs.get_mut(&index),
-			StreamType::Source => self.sources.get_mut(&index),
-			StreamType::SourceOutput => self.source_outputs.get_mut(&index),
-		};
-
-		if let Some(stream) = entry { stream.data = data; }
-		else {
-			let source_str = stream.monitor_index.to_string();
-			let monitor = self.create_monitor_stream(t, if t == StreamType::SinkInput { None } else { Some(&source_str) }, index);
-			let data = StreamData { data, peak: 0, monitor, monitor_index: stream.monitor_index };
-			match t {
-				StreamType::Sink => self.sinks.insert(index, data),
-				StreamType::SinkInput => self.sink_inputs.insert(index, data),
-				StreamType::Source => self.sources.insert(index, data),
-				StreamType::SourceOutput => self.source_outputs.insert(index, data)
-			};
-		}
-	}
-
-
-	/**
-	 * Removes a stream from the store, stopping the monitor, if there is one.
-	 * This method is called by the update method, the data is provided by the pulse server.
-	 *
-	 * * `t`     - The type of stream to remove.
-	 * * `index` - The index of the stream to remove.
-	 */
-
-	fn remove_stream(&mut self, t: StreamType, index: u32) {
-		let stream_opt = match t {
-			StreamType::Sink => self.sinks.get_mut(&index),
-			StreamType::SinkInput => self.sink_inputs.get_mut(&index),
-			StreamType::Source => self.sources.get_mut(&index),
-			StreamType::SourceOutput => self.source_outputs.get_mut(&index),
-		};
-
-		if let Some(stream) = stream_opt {
-			let mut monitor = stream.monitor.borrow_mut();
-			let mut mainloop = self.mainloop.borrow_mut();
-			mainloop.lock();
-			if monitor.get_state().is_good() {
-				monitor.set_read_callback(None);
-				let _ = monitor.disconnect();
-			}
-			mainloop.unlock();
-		}
-
-		match t {
-			StreamType::Sink => self.sinks.remove(&index),
-			StreamType::SinkInput => self.sink_inputs.remove(&index),
-			StreamType::Source => self.sources.remove(&index),
-			StreamType::SourceOutput => self.source_outputs.remove(&index),
-		};
-	}
-
-
-	/**
-	 * Updates a stored stream's peak.
-	 * This method is called by the update method, the data is provided by a monitor stream.
-	 *
-	 * * `t`     - The type of stream to update.
-	 * * `index` - The index of the stream to update.
-	 * * `peak`  - The peak value to store.
-	 */
-
-	fn update_peak(&mut self, t: StreamType, index: u32, peak: u32) {
-		match t {
-			StreamType::Sink => self.sinks.entry(index).and_modify(|e| e.peak = peak),
-			StreamType::SinkInput => self.sink_inputs.entry(index).and_modify(|e| e.peak = peak),
-			StreamType::Source => self.sources.entry(index).and_modify(|e| e.peak = peak),
-			StreamType::SourceOutput => self.source_outputs.entry(index).and_modify(|e| e.peak = peak)
-		};
-	}
-
-
-	/**
-	 * Creates a monitor stream for the stream specified, and returns it.
-	 * Panics if there's an error.
-	 * TODO: Don't panic.
-	 *
-	 * * `t`            - The type of stream to monitor.
-	 * * `source`       - The source string of the stream, if one is needed.
-	 * * `stream_index` - The index of the stream to monitor.
-	 */
-
-	fn create_monitor_stream(&mut self, t: StreamType, source: Option<&str>, stream_index: u32) -> Shared<Stream> {
-		fn read_callback(stream: &mut Stream, t: StreamType, index: u32, tx: &Sender<TxMessage>) {
-			let mut raw_peak = 0.0;
-			while stream.readable_size().is_some() {
-				match stream.peek().unwrap() {
-					PeekResult::Hole(_) => stream.discard().unwrap(),
-					PeekResult::Data(b) => {
-						let buf = slice_as_array!(b, [u8; 4]).expect("Bad length.");
-						raw_peak = f32::from_le_bytes(*buf).max(raw_peak);
-						stream.discard().unwrap();
-					},
-					_ => break
-				}
-			}
-			let peak = (raw_peak.sqrt() * 65535.0 * 1.5).round() as u32;
-			tx.send(TxMessage::Peak(t, index, peak)).unwrap();
-		}
-
-		let mut attr = BufferAttr::default();
-		attr.fragsize = 4;
-		attr.maxlength = u32::MAX;
-		
-		let spec = Spec { channels: 1, format: Format::F32le, rate: 30 };
-		assert!(spec.is_valid());
-		
-		let s = Shared::new(Stream::new(&mut self.context.borrow_mut(), "Peak Detect", &spec, None).unwrap());
-		{
-			let mut stream = s.borrow_mut();
-			if t == StreamType::SinkInput {
-				stream.set_monitor_stream(stream_index).unwrap();
-			}
-
-			let mut mainloop = self.mainloop.borrow_mut();
-			mainloop.lock();
-			stream.connect_record(source, Some(&attr),
-				StreamFlagSet::DONT_MOVE | StreamFlagSet::ADJUST_LATENCY | StreamFlagSet::PEAK_DETECT).unwrap();
-			mainloop.unlock();
-
-			let t = t.clone();
-			let sc = s.clone();
-			let txc = self.channel.tx.clone();
-			stream.set_read_callback(Some(Box::new(move |_| read_callback(&mut sc.borrow_mut(), t, stream_index, &txc))));
-		}
-
-		return s;
-	}
-
-
-	/**
-	 * Updates a card in the store, or creates a new one.
-	 * This method is called by the update method, the data is provided by the pulse server.
-	 *
-	 * * `data` - The card's data.
-	 */
-
-	fn update_card(&mut self, data: &CardData) {
-		let index = data.index;
-		self.cards.insert(index, data.clone());
-	}
-
-
-	/**
-	 * Removes a card from the store.
-	 * This method is called by the update method, the data is provided by the pulse server.
-	 *
-	 * * `index` - The index of the stream to remove.
-	 */
-
-	fn remove_card(&mut self, index: u32) {
-		self.cards.remove(&index);
-	}
+    /**
+     * Creates a new pulse controller, configuring (but not initializing) the pulse connection.
+     */
+
+    pub fn new() -> Self {
+        let mut proplist = Proplist::new().unwrap();
+        proplist
+            .set_str(properties::APPLICATION_NAME, "Myxer")
+            .unwrap();
+
+        let mainloop = Shared::new(Mainloop::new().expect("Failed to initialize pulse mainloop."));
+
+        let context = Shared::new(
+            Context::new_with_proplist(&*mainloop.borrow(), "Myxer Context", &proplist)
+                .expect("Failed to initialize pulse context."),
+        );
+
+        let (tx, rx) = channel::<TxMessage>();
+
+        Pulse {
+            mainloop,
+            context,
+            channel: Channel { tx, rx },
+
+            default_sink: u32::MAX,
+            default_source: u32::MAX,
+            active_sink: u32::MAX,
+            active_source: u32::MAX,
+
+            sinks: HashMap::new(),
+            sink_inputs: HashMap::new(),
+            sources: HashMap::new(),
+            source_outputs: HashMap::new(),
+            cards: HashMap::new(),
+        }
+    }
+
+    /**
+     * Initiates a connection to pulse. Blocks until success, panics on failure.
+     * TODO: Graceful error handling, with debug message.
+     * TODO: Try to see if there's a way to avoid using unsafe? It's in the docs...  but...?
+     */
+
+    pub fn connect(&mut self) {
+        let mut mainloop = self.mainloop.borrow_mut();
+        let mut ctx = self.context.borrow_mut();
+
+        let mainloop_shr_ref = self.mainloop.clone();
+        let ctx_shr_ref = self.context.clone();
+
+        ctx.set_state_callback(Some(Box::new(move || {
+            match unsafe { (*ctx_shr_ref.as_ptr()).get_state() } {
+                ContextState::Ready | ContextState::Failed | ContextState::Terminated => unsafe {
+                    (*mainloop_shr_ref.as_ptr()).signal(false);
+                },
+                _ => {}
+            }
+        })));
+
+        ctx.connect(None, CtxFlagSet::NOFLAGS, None)
+            .expect("Failed to connect to the pulse server.");
+
+        mainloop.lock();
+        mainloop.start().expect("Failed to start pulse mainloop.");
+
+        loop {
+            match ctx.get_state() {
+                ContextState::Ready => {
+                    ctx.set_state_callback(None);
+                    mainloop.unlock();
+                    break;
+                }
+                ContextState::Failed | ContextState::Terminated => {
+                    eprintln!("Context state failed/terminated, quitting...");
+                    mainloop.unlock();
+                    mainloop.stop();
+                    panic!("Pulse session terminated.");
+                }
+                _ => {
+                    mainloop.wait();
+                }
+            }
+        }
+
+        drop(ctx);
+        drop(mainloop);
+        self.subscribe();
+    }
+
+    /**
+     * Asynchronously sets the default sink to the index provided.
+     * This is sometimes described as the fallback device.
+     *
+     * * `sink` - The sink index to set as the default.
+     */
+
+    pub fn set_default_sink(&self, sink: u32) {
+        if let Some(sink) = self.sinks.get(&sink) {
+            let mut mainloop = self.mainloop.borrow_mut();
+            mainloop.lock();
+            self.context
+                .borrow_mut()
+                .set_default_sink(&sink.data.name, |_| ());
+            mainloop.unlock();
+        }
+    }
+
+    /**
+     * Asynchronously sets the default source to the index provided.
+     * This is sometimes described as the fallback device.
+     *
+     * * `source` - The source index to set as the default.
+     */
+
+    pub fn set_default_source(&self, source: u32) {
+        if let Some(source) = self.sources.get(&source) {
+            let mut mainloop = self.mainloop.borrow_mut();
+            mainloop.lock();
+            self.context
+                .borrow_mut()
+                .set_default_source(&source.data.name, |_| ());
+            mainloop.unlock();
+        }
+    }
+
+    /**
+     * Sets the 'active' sink to the index provided.
+     * This is the sink that is currently displayed on the interface.
+     *
+     * * `sink` - The sink index to set as active.
+     */
+
+    pub fn set_active_sink(&mut self, sink: u32) {
+        self.active_sink = sink;
+    }
+
+    /**
+     * Sets the 'active' source to the index provided.
+     * This is the source that is currently displayed on the interface.
+     *
+     * * `source` - The source to set as active.
+     */
+
+    pub fn set_active_source(&mut self, source: u32) {
+        self.active_source = source;
+    }
+
+    /**
+     * Sets the volume of the stream to the volumes specified.
+     * This operation is asynchronous, so changes will not be reflected immediately.
+     *
+     * * `t`       - The type of stream to set the volume of.
+     * * `index`   - The index of the stream to set the volume of.
+     * * `volumes` - The desired volumes to set the channels of the stream to.
+     */
+
+    pub fn set_volume(&self, t: StreamType, index: u32, volumes: ChannelVolumes) {
+        let mut introspect = self.context.borrow().introspect();
+        let mut mainloop = self.mainloop.borrow_mut();
+        mainloop.lock();
+
+        match t {
+            StreamType::Sink => drop(introspect.set_sink_volume_by_index(index, &volumes, None)),
+            StreamType::SinkInput => drop(introspect.set_sink_input_volume(index, &volumes, None)),
+            StreamType::Source => {
+                drop(introspect.set_source_volume_by_index(index, &volumes, None))
+            }
+            StreamType::SourceOutput => {
+                drop(introspect.set_source_output_volume(index, &volumes, None))
+            }
+        };
+
+        mainloop.unlock();
+    }
+
+    /**
+     * Mutes or unmutes a stream.
+     * This operation is asynchronous, so changes will not be reflected immediately.
+     *
+     * * `t`     - The type of stream to update.
+     * * `index` - The index of the stream to update.
+     * * `mute`  - Whether the stream should be muted or not.
+     */
+
+    pub fn set_muted(&self, t: StreamType, index: u32, mute: bool) {
+        let mut introspect = self.context.borrow().introspect();
+        let mut mainloop = self.mainloop.borrow_mut();
+        mainloop.lock();
+
+        match t {
+            StreamType::Sink => drop(introspect.set_sink_mute_by_index(index, mute, None)),
+            StreamType::SinkInput => drop(introspect.set_sink_input_mute(index, mute, None)),
+            StreamType::Source => drop(introspect.set_source_mute_by_index(index, mute, None)),
+            StreamType::SourceOutput => drop(introspect.set_source_output_mute(index, mute, None)),
+        };
+
+        mainloop.unlock();
+    }
+
+    /**
+     * Set's a sound card's profile.
+     * This effects how the card behaves, and how the system can utilize it.
+     *
+     * * `index`   - The card index to update.
+     * * `profile` - The profile name to update the card to.
+     */
+
+    pub fn set_card_profile(&self, index: u32, profile: &str) {
+        let mut introspect = self.context.borrow().introspect();
+        let mut mainloop = self.mainloop.borrow_mut();
+        mainloop.lock();
+        introspect.set_card_profile_by_index(index, profile, None);
+        mainloop.unlock();
+    }
+
+    /**
+     * Binds listeners to server events, and triggers an
+     * initial sweep to populate the internal stores.
+     * Called by connect(), separated for readability.
+     */
+
+    fn subscribe(&mut self) {
+        /** Updates the client when the server information changes. */
+        fn tx_server(tx: &Sender<TxMessage>, item: &ServerInfo<'_>) {
+            tx.send(TxMessage::Default(
+                item.default_sink_name.clone().unwrap().into_owned(),
+                item.default_source_name.clone().unwrap().into_owned(),
+            ))
+            .unwrap();
+        };
+
+        /** Updates the client when a sink changes. */
+        fn tx_sink(tx: &Sender<TxMessage>, result: ListResult<&SinkInfo<'_>>) {
+            if let ListResult::Item(item) = result {
+                tx.send(TxMessage::StreamUpdate(
+                    StreamType::Sink,
+                    TxStreamData {
+                        data: MeterData {
+                            t: StreamType::Sink,
+                            index: item.index,
+                            icon: "multimedia-volume-control".to_owned(),
+                            name: item.name.clone().unwrap().into_owned(),
+                            description: item.description.clone().unwrap().into_owned(),
+                            volume: item.volume,
+                            muted: item.mute,
+                        },
+                        monitor_index: item.monitor_source,
+                    },
+                ))
+                .unwrap();
+            };
+        };
+
+        /** Updates the client when a sink input changes. */
+        fn tx_sink_input(tx: &Sender<TxMessage>, result: ListResult<&SinkInputInfo<'_>>) {
+            if let ListResult::Item(item) = result {
+                tx.send(TxMessage::StreamUpdate(
+                    StreamType::SinkInput,
+                    TxStreamData {
+                        data: MeterData {
+                            t: StreamType::SinkInput,
+                            index: item.index,
+                            icon: item
+                                .proplist
+                                .get_str("application.icon_name")
+                                .unwrap_or_else(|| "audio-card".to_owned()),
+                            name: item.name.clone().unwrap().into_owned(),
+                            description: item
+                                .proplist
+                                .get_str("application.name")
+                                .unwrap_or("".to_owned()),
+                            volume: item.volume,
+                            muted: item.mute,
+                        },
+                        monitor_index: item.sink,
+                    },
+                ))
+                .unwrap();
+            };
+        };
+
+        /** Updates the client when a source changes. */
+        fn tx_source(tx: &Sender<TxMessage>, result: ListResult<&SourceInfo<'_>>) {
+            if let ListResult::Item(item) = result {
+                let name = item.name.clone().unwrap().into_owned();
+                if name.ends_with(".monitor") {
+                    return;
+                }
+                tx.send(TxMessage::StreamUpdate(
+                    StreamType::Source,
+                    TxStreamData {
+                        data: MeterData {
+                            t: StreamType::Source,
+                            index: item.index,
+                            icon: "audio-input-microphone".to_owned(),
+                            name: item.name.clone().unwrap().into_owned(),
+                            description: item.description.clone().unwrap().into_owned(),
+                            volume: item.volume,
+                            muted: item.mute,
+                        },
+                        monitor_index: item.index,
+                    },
+                ))
+                .unwrap();
+            };
+        };
+
+        /** Updates the client when a source output changes. */
+        fn tx_source_output(tx: &Sender<TxMessage>, result: ListResult<&SourceOutputInfo<'_>>) {
+            if let ListResult::Item(item) = result {
+                let app_id = item
+                    .proplist
+                    .get_str("application.process.binary")
+                    .unwrap_or("".to_owned())
+                    .to_lowercase();
+                if app_id.contains("pavucontrol") || app_id.contains("myxer") {
+                    return;
+                }
+                tx.send(TxMessage::StreamUpdate(
+                    StreamType::SourceOutput,
+                    TxStreamData {
+                        data: MeterData {
+                            t: StreamType::SourceOutput,
+                            index: item.index,
+                            icon: item
+                                .proplist
+                                .get_str("application.icon_name")
+                                .unwrap_or_else(|| "audio-card".to_owned()),
+                            name: item.name.clone().unwrap().into_owned(),
+                            description: item
+                                .proplist
+                                .get_str("application.name")
+                                .unwrap_or("".to_owned()),
+                            volume: item.volume,
+                            muted: item.mute,
+                        },
+                        monitor_index: item.source,
+                    },
+                ))
+                .unwrap();
+            };
+        };
+
+        /** Updates the client when a sound card changes. */
+        fn tx_card(tx: &Sender<TxMessage>, result: ListResult<&CardInfo<'_>>) {
+            if let ListResult::Item(item) = result {
+                tx.send(TxMessage::CardUpdate(CardData {
+                    index: item.index,
+                    name: item
+                        .proplist
+                        .get_str("device.description")
+                        .unwrap_or("".to_owned()),
+                    icon: item
+                        .proplist
+                        .get_str("device.icon_name")
+                        .unwrap_or_else(|| "audio-card-pci".to_owned()),
+                    profiles: item
+                        .profiles
+                        .iter()
+                        .map(|p| {
+                            (
+                                p.name.as_ref().unwrap().clone().into_owned(),
+                                p.description.as_ref().unwrap().clone().into_owned(),
+                            )
+                        })
+                        .collect(),
+                    active_profile: item
+                        .active_profile
+                        .as_ref()
+                        .unwrap()
+                        .name
+                        .as_ref()
+                        .unwrap()
+                        .clone()
+                        .into_owned(),
+                }))
+                .unwrap();
+            }
+        }
+
+        let mut mainloop = self.mainloop.borrow_mut();
+        mainloop.lock();
+        let mut context = self.context.borrow_mut();
+        let introspect = context.introspect();
+
+        let tx = self.channel.tx.clone();
+        introspect.get_sink_info_list(move |res| tx_sink(&tx, res));
+        let tx = self.channel.tx.clone();
+        introspect.get_sink_input_info_list(move |res| tx_sink_input(&tx, res));
+        let tx = self.channel.tx.clone();
+        introspect.get_source_info_list(move |res| tx_source(&tx, res));
+        let tx = self.channel.tx.clone();
+        introspect.get_source_output_info_list(move |res| tx_source_output(&tx, res));
+        let tx = self.channel.tx.clone();
+        introspect.get_card_info_list(move |res| tx_card(&tx, res));
+        let tx = self.channel.tx.clone();
+        introspect.get_server_info(move |res| tx_server(&tx, res));
+
+        let tx = self.channel.tx.clone();
+        context.subscribe(
+            InterestMaskSet::SERVER
+                | InterestMaskSet::SINK
+                | InterestMaskSet::SINK_INPUT
+                | InterestMaskSet::SOURCE
+                | InterestMaskSet::SOURCE_OUTPUT
+                | InterestMaskSet::CARD,
+            |_| (),
+        );
+        context.set_subscribe_callback(Some(Box::new(move |fac, op, index| {
+            let tx = tx.clone();
+            let facility = fac.unwrap();
+            let operation = op.unwrap();
+
+            match facility {
+                Facility::Server => {
+                    drop(introspect.get_server_info(move |res| tx_server(&tx, res)))
+                }
+                Facility::Sink => match operation {
+                    Operation::Removed => tx
+                        .send(TxMessage::StreamRemove(StreamType::Sink, index))
+                        .unwrap(),
+                    _ => {
+                        drop(introspect.get_sink_info_by_index(index, move |res| tx_sink(&tx, res)))
+                    }
+                },
+                Facility::SinkInput => match operation {
+                    Operation::Removed => tx
+                        .send(TxMessage::StreamRemove(StreamType::SinkInput, index))
+                        .unwrap(),
+                    _ => drop(
+                        introspect.get_sink_input_info(index, move |res| tx_sink_input(&tx, res)),
+                    ),
+                },
+                Facility::Source => match operation {
+                    Operation::Removed => tx
+                        .send(TxMessage::StreamRemove(StreamType::Source, index))
+                        .unwrap(),
+                    _ => drop(
+                        introspect.get_source_info_by_index(index, move |res| tx_source(&tx, res)),
+                    ),
+                },
+                Facility::SourceOutput => match operation {
+                    Operation::Removed => tx
+                        .send(TxMessage::StreamRemove(StreamType::SourceOutput, index))
+                        .unwrap(),
+                    _ => drop(
+                        introspect
+                            .get_source_output_info(index, move |res| tx_source_output(&tx, res)),
+                    ),
+                },
+                Facility::Card => match operation {
+                    Operation::Removed => tx.send(TxMessage::CardRemove(index)).unwrap(),
+                    _ => {
+                        drop(introspect.get_card_info_by_index(index, move |res| tx_card(&tx, res)))
+                    }
+                },
+                _ => (),
+            };
+        })));
+
+        mainloop.unlock();
+    }
+
+    /**
+     * Handles queued messages from the pulse thread, updating the internal storage.
+     * Returns a boolean indicating that a layout refresh is required.
+     */
+
+    pub fn update(&mut self) -> bool {
+        let mut received = false;
+
+        loop {
+            let res = self.channel.rx.try_recv();
+            match res {
+                Ok(res) => {
+                    received = true;
+                    match res {
+                        TxMessage::Default(sink, source) => self.update_default(sink, source),
+                        TxMessage::StreamUpdate(t, data) => self.update_stream(t, &data),
+                        TxMessage::StreamRemove(t, ind) => self.remove_stream(t, ind),
+                        TxMessage::CardUpdate(data) => self.update_card(&data),
+                        TxMessage::CardRemove(ind) => self.remove_card(ind),
+                        TxMessage::Peak(t, ind, peak) => self.update_peak(t, ind, peak),
+                    }
+                }
+                _ => break,
+            }
+        }
+
+        received
+    }
+
+    /**
+     * Closes the connection to the pulse server, and cleans up any dangling monitors.
+     * After this operation, no other methods should be called, and the instance should be freed from memory.
+     */
+
+    pub fn cleanup(&mut self) {
+        while let Some((i, _)) = self.sinks.iter().next() {
+            let i = *i;
+            self.remove_stream(StreamType::Sink, i)
+        }
+        while let Some((i, _)) = self.sink_inputs.iter().next() {
+            let i = *i;
+            self.remove_stream(StreamType::SinkInput, i)
+        }
+        while let Some((i, _)) = self.sources.iter().next() {
+            let i = *i;
+            self.remove_stream(StreamType::Source, i)
+        }
+        while let Some((i, _)) = self.source_outputs.iter().next() {
+            let i = *i;
+            self.remove_stream(StreamType::SourceOutput, i)
+        }
+
+        let mut mainloop = self.mainloop.borrow_mut();
+        mainloop.stop();
+    }
+
+    /**
+     * Updates the stored default sink and source to the ones identified.
+     * This method is called by the update method, the names are provided by the pulse server.
+     *
+     * * `sink`   - The default sink.
+     * * `source` - The default source.
+     */
+
+    fn update_default(&mut self, sink: String, source: String) {
+        for (i, v) in &self.sinks {
+            if v.data.name == sink {
+                self.default_sink = *i;
+                self.active_sink = *i;
+                break;
+            }
+        }
+
+        for (i, v) in &self.sources {
+            if v.data.name == source {
+                self.default_source = *i;
+                self.active_source = *i;
+                break;
+            }
+        }
+    }
+
+    /**
+     * Updates a stream in the store, or creates a new one and begins monitoring the peaks.
+     * This method is called by the update method, the data is provided by the pulse server.
+     *
+     * * `t`      - The type of stream to update.
+     * * `stream` - The new stream's data.
+     */
+
+    fn update_stream(&mut self, t: StreamType, stream: &TxStreamData) {
+        let data = stream.data.clone();
+        let index = data.index;
+
+        let entry = match t {
+            StreamType::Sink => self.sinks.get_mut(&index),
+            StreamType::SinkInput => self.sink_inputs.get_mut(&index),
+            StreamType::Source => self.sources.get_mut(&index),
+            StreamType::SourceOutput => self.source_outputs.get_mut(&index),
+        };
+
+        if let Some(stream) = entry {
+            stream.data = data;
+        } else {
+            let source_str = stream.monitor_index.to_string();
+            let monitor = self.create_monitor_stream(
+                t,
+                if t == StreamType::SinkInput {
+                    None
+                } else {
+                    Some(&source_str)
+                },
+                index,
+            );
+            let data = StreamData {
+                data,
+                peak: 0,
+                monitor,
+                monitor_index: stream.monitor_index,
+            };
+            match t {
+                StreamType::Sink => self.sinks.insert(index, data),
+                StreamType::SinkInput => self.sink_inputs.insert(index, data),
+                StreamType::Source => self.sources.insert(index, data),
+                StreamType::SourceOutput => self.source_outputs.insert(index, data),
+            };
+        }
+    }
+
+    /**
+     * Removes a stream from the store, stopping the monitor, if there is one.
+     * This method is called by the update method, the data is provided by the pulse server.
+     *
+     * * `t`     - The type of stream to remove.
+     * * `index` - The index of the stream to remove.
+     */
+
+    fn remove_stream(&mut self, t: StreamType, index: u32) {
+        let stream_opt = match t {
+            StreamType::Sink => self.sinks.get_mut(&index),
+            StreamType::SinkInput => self.sink_inputs.get_mut(&index),
+            StreamType::Source => self.sources.get_mut(&index),
+            StreamType::SourceOutput => self.source_outputs.get_mut(&index),
+        };
+
+        if let Some(stream) = stream_opt {
+            let mut monitor = stream.monitor.borrow_mut();
+            let mut mainloop = self.mainloop.borrow_mut();
+            mainloop.lock();
+            if monitor.get_state().is_good() {
+                monitor.set_read_callback(None);
+                let _ = monitor.disconnect();
+            }
+            mainloop.unlock();
+        }
+
+        match t {
+            StreamType::Sink => self.sinks.remove(&index),
+            StreamType::SinkInput => self.sink_inputs.remove(&index),
+            StreamType::Source => self.sources.remove(&index),
+            StreamType::SourceOutput => self.source_outputs.remove(&index),
+        };
+    }
+
+    /**
+     * Updates a stored stream's peak.
+     * This method is called by the update method, the data is provided by a monitor stream.
+     *
+     * * `t`     - The type of stream to update.
+     * * `index` - The index of the stream to update.
+     * * `peak`  - The peak value to store.
+     */
+
+    fn update_peak(&mut self, t: StreamType, index: u32, peak: u32) {
+        match t {
+            StreamType::Sink => self.sinks.entry(index).and_modify(|e| e.peak = peak),
+            StreamType::SinkInput => self.sink_inputs.entry(index).and_modify(|e| e.peak = peak),
+            StreamType::Source => self.sources.entry(index).and_modify(|e| e.peak = peak),
+            StreamType::SourceOutput => self
+                .source_outputs
+                .entry(index)
+                .and_modify(|e| e.peak = peak),
+        };
+    }
+
+    /**
+     * Creates a monitor stream for the stream specified, and returns it.
+     * Panics if there's an error.
+     * TODO: Don't panic.
+     *
+     * * `t`            - The type of stream to monitor.
+     * * `source`       - The source string of the stream, if one is needed.
+     * * `stream_index` - The index of the stream to monitor.
+     */
+
+    fn create_monitor_stream(
+        &mut self,
+        t: StreamType,
+        source: Option<&str>,
+        stream_index: u32,
+    ) -> Shared<Stream> {
+        fn read_callback(stream: &mut Stream, t: StreamType, index: u32, tx: &Sender<TxMessage>) {
+            let mut raw_peak = 0.0;
+            while stream.readable_size().is_some() {
+                match stream.peek().unwrap() {
+                    PeekResult::Hole(_) => stream.discard().unwrap(),
+                    PeekResult::Data(b) => {
+                        let buf = slice_as_array!(b, [u8; 4]).expect("Bad length.");
+                        raw_peak = f32::from_le_bytes(*buf).max(raw_peak);
+                        stream.discard().unwrap();
+                    }
+                    _ => break,
+                }
+            }
+            let peak = (raw_peak.sqrt() * 65535.0 * 1.5).round() as u32;
+            tx.send(TxMessage::Peak(t, index, peak)).unwrap();
+        }
+
+        let mut attr = BufferAttr::default();
+        attr.fragsize = 4;
+        attr.maxlength = u32::MAX;
+
+        let spec = Spec {
+            channels: 1,
+            format: Format::F32le,
+            rate: 30,
+        };
+        assert!(spec.is_valid());
+
+        let s = Shared::new(
+            Stream::new(&mut self.context.borrow_mut(), "Peak Detect", &spec, None).unwrap(),
+        );
+        {
+            let mut stream = s.borrow_mut();
+            if t == StreamType::SinkInput {
+                stream.set_monitor_stream(stream_index).unwrap();
+            }
+
+            let mut mainloop = self.mainloop.borrow_mut();
+            mainloop.lock();
+            stream
+                .connect_record(
+                    source,
+                    Some(&attr),
+                    StreamFlagSet::DONT_MOVE
+                        | StreamFlagSet::ADJUST_LATENCY
+                        | StreamFlagSet::PEAK_DETECT,
+                )
+                .unwrap();
+            mainloop.unlock();
+
+            let t = t.clone();
+            let sc = s.clone();
+            let txc = self.channel.tx.clone();
+            stream.set_read_callback(Some(Box::new(move |_| {
+                read_callback(&mut sc.borrow_mut(), t, stream_index, &txc)
+            })));
+        }
+
+        return s;
+    }
+
+    /**
+     * Updates a card in the store, or creates a new one.
+     * This method is called by the update method, the data is provided by the pulse server.
+     *
+     * * `data` - The card's data.
+     */
+
+    fn update_card(&mut self, data: &CardData) {
+        let index = data.index;
+        self.cards.insert(index, data.clone());
+    }
+
+    /**
+     * Removes a card from the store.
+     * This method is called by the update method, the data is provided by the pulse server.
+     *
+     * * `index` - The index of the stream to remove.
+     */
+
+    fn remove_card(&mut self, index: u32) {
+        self.cards.remove(&index);
+    }
 }

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -3,11 +3,10 @@
  * Shamelessly copied from https://gist.github.com/stevedonovan/7e3a6d8c8921e3eff16c4b11ab82b8d7.
  */
 
-use std::rc::Rc;
-use std::cell::{RefCell, Ref, RefMut};
-use std::ops::Deref;
+use std::cell::{Ref, RefCell, RefMut};
 use std::fmt;
-
+use std::ops::Deref;
+use std::rc::Rc;
 
 /**
  * Represents a shared pointer to an object
@@ -16,78 +15,74 @@ use std::fmt;
 
 #[derive(Clone)]
 pub struct Shared<T> {
-	v: Rc<RefCell<T>>
+    v: Rc<RefCell<T>>,
 }
 
-impl <T> Shared<T> {
+impl<T> Shared<T> {
+    /**
+     * Creates a new Shared with the contents provided.
+     */
 
-	/**
-	 * Creates a new Shared with the contents provided.
-	 */
-
-	pub fn new(t: T) -> Shared<T> {
-		Shared { v: Rc::new(RefCell::new(t)) }
-	}
+    pub fn new(t: T) -> Shared<T> {
+        Shared {
+            v: Rc::new(RefCell::new(t)),
+        }
+    }
 }
 
-impl <T> Shared<T> {
+impl<T> Shared<T> {
+    /**
+     * Borrows an immutable reference to the stored object.
+     */
 
-	/**
-	 * Borrows an immutable reference to the stored object.
-	 */
+    pub fn borrow(&self) -> Ref<T> {
+        self.v.borrow()
+    }
 
-	pub fn borrow(&self) -> Ref<T> {
-		self.v.borrow()
-	}
+    /**
+     * Borrows a mutable reference to the stored object.
+     */
 
+    pub fn borrow_mut(&self) -> RefMut<T> {
+        self.v.borrow_mut()
+    }
 
-	/**
-	 * Borrows a mutable reference to the stored object.
-	 */
+    /**
+     * Borrows a mutable pointer to the stored object.
+     */
 
-	pub fn borrow_mut(&self) -> RefMut<T> {
-		self.v.borrow_mut()
-	}
+    pub fn as_ptr(&self) -> *mut T {
+        self.v.as_ptr()
+    }
 
+    /**
+     * Replaces the stored object with a new one.
+     */
 
-	/**
-	 * Borrows a mutable pointer to the stored object.
-	 */
+    pub fn replace(&self, t: T) -> T {
+        self.v.replace(t)
+    }
 
-	pub fn as_ptr(&self) -> *mut T {
-		self.v.as_ptr()
-	}
+    /**
+     * Creates a new pointer to the stored memory.
+     * This operation is inexpensive, and does not clone the underlying object.
+     */
 
-
-	/**
-	 * Replaces the stored object with a new one.
-	 */
-
-	pub fn replace(&self, t: T) -> T {
-		self.v.replace(t)
-	}
-
-
-	/**
-	 * Creates a new pointer to the stored memory.
-	 * This operation is inexpensive, and does not clone the underlying object.
-	 */
-
-	pub fn clone(&self) -> Shared<T> {
-		Shared { v: Rc::clone(&self.v) }
-	}
+    pub fn clone(&self) -> Shared<T> {
+        Shared {
+            v: Rc::clone(&self.v),
+        }
+    }
 }
 
-
-impl <T: fmt::Display> fmt::Display for Shared<T> {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-		write!(f, "{}", self.deref())
-	}
+impl<T: fmt::Display> fmt::Display for Shared<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.deref())
+    }
 }
 
-
-impl <T: fmt::Debug> fmt::Debug for Shared<T> {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-		write!(f, "{:?}", self.deref())
-	}
+impl<T: fmt::Debug> fmt::Debug for Shared<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self.deref())
+    }
 }

--- a/src/window/about.rs
+++ b/src/window/about.rs
@@ -4,24 +4,23 @@
 
 use gtk::prelude::*;
 
-
 /**
  * Creates and runs the About popup window,
  * which contains information about the app, license, and Auri.
  */
 
 pub fn about() {
-	let about = gtk::AboutDialog::new();
-	about.set_logo_icon_name(Some("multimedia-volume-control"));
-	about.set_program_name("Myxer");
-	about.set_version(Some("1.1.3"));
-	about.set_comments(Some("A modern Volume Mixer for PulseAudio."));
-	about.set_website(Some("https://myxer.aurailus.com"));
-	about.set_copyright(Some("© 2021 Auri Collings"));
-	about.set_license_type(gtk::License::Gpl30);
-	about.add_credit_section("Created by", &[ "Auri Collings" ]);
-	about.add_credit_section("libpulse-binding by", &[ "Lyndon Brown" ]);
+    let about = gtk::AboutDialog::new();
+    about.set_logo_icon_name(Some("multimedia-volume-control"));
+    about.set_program_name("Myxer");
+    about.set_version(Some("1.1.3"));
+    about.set_comments(Some("A modern Volume Mixer for PulseAudio."));
+    about.set_website(Some("https://myxer.aurailus.com"));
+    about.set_copyright(Some("© 2021 Auri Collings"));
+    about.set_license_type(gtk::License::Gpl30);
+    about.add_credit_section("Created by", &["Auri Collings"]);
+    about.add_credit_section("libpulse-binding by", &["Lyndon Brown"]);
 
-	about.connect_response(|about, _| about.close());
-	about.run();
+    about.connect_response(|about, _| about.close());
+    about.run();
 }

--- a/src/window/myxer.rs
+++ b/src/window/myxer.rs
@@ -4,95 +4,93 @@
 
 use std::collections::HashMap;
 
-use gtk::prelude::*;
 use gio::prelude::*;
+use gtk::prelude::*;
 
 use super::style;
+use super::{about, Profiles};
+use crate::meter::{Meter, SinkMeter, SourceMeter, StreamMeter};
 use crate::pulse::Pulse;
 use crate::shared::Shared;
-use super::{ about, Profiles };
-use crate::meter::{ Meter, SinkMeter, SourceMeter, StreamMeter };
-
 
 /**
  * Stores meter widgets and options.
  */
 
 pub struct Meters {
-	pub sink: SinkMeter,
-	pub sink_box: gtk::Box,
-	pub sink_inputs: HashMap<u32, StreamMeter>,
-	pub sink_inputs_box: gtk::Box,
-	
-	pub source: SourceMeter,
-	pub source_box: gtk::Box,
-	pub source_outputs: HashMap<u32, StreamMeter>,
-	pub source_outputs_box: gtk::Box,
+    pub sink: SinkMeter,
+    pub sink_box: gtk::Box,
+    pub sink_inputs: HashMap<u32, StreamMeter>,
+    pub sink_inputs_box: gtk::Box,
 
-	pub show_visualizers: bool,
-	pub separate_channels: bool
+    pub source: SourceMeter,
+    pub source_box: gtk::Box,
+    pub source_outputs: HashMap<u32, StreamMeter>,
+    pub source_outputs_box: gtk::Box,
+
+    pub show_visualizers: bool,
+    pub separate_channels: bool,
 }
 
 impl Meters {
+    /**
+     * Creates the Struct, and some base widgets,
+     * including the Sink and Source meters.
+     *
+     * * `pulse` - The Pulse instance used by the app.
+     */
 
-	/**
-	 * Creates the Struct, and some base widgets,
-	 * including the Sink and Source meters.
-	 *
-	 * * `pulse` - The Pulse instance used by the app.
-	 */
+    pub fn new(pulse: &Shared<Pulse>) -> Self {
+        let sink = SinkMeter::new(pulse.clone());
 
-	pub fn new(pulse: &Shared<Pulse>) -> Self {
-		let sink = SinkMeter::new(pulse.clone());
+        let sink_box = gtk::Box::new(gtk::Orientation::Horizontal, 0);
+        sink_box.get_style_context().add_class("pad_side");
+        sink_box.add(&sink.widget);
 
-		let sink_box = gtk::Box::new(gtk::Orientation::Horizontal, 0);
-		sink_box.get_style_context().add_class("pad_side");
-		sink_box.add(&sink.widget);
+        let source = SourceMeter::new(pulse.clone());
 
-		let source = SourceMeter::new(pulse.clone());
+        let source_box = gtk::Box::new(gtk::Orientation::Horizontal, 0);
+        source_box.get_style_context().add_class("pad_side");
+        source_box.add(&source.widget);
 
-		let source_box = gtk::Box::new(gtk::Orientation::Horizontal, 0);
-		source_box.get_style_context().add_class("pad_side");
-		source_box.add(&source.widget);
+        let sink_inputs_box = gtk::Box::new(gtk::Orientation::Horizontal, 0);
+        sink_inputs_box.get_style_context().add_class("pad_side");
 
-		let sink_inputs_box = gtk::Box::new(gtk::Orientation::Horizontal, 0);
-		sink_inputs_box.get_style_context().add_class("pad_side");
-		
-		let source_outputs_box = gtk::Box::new(gtk::Orientation::Horizontal, 0);
-		source_outputs_box.get_style_context().add_class("pad_side");
+        let source_outputs_box = gtk::Box::new(gtk::Orientation::Horizontal, 0);
+        source_outputs_box.get_style_context().add_class("pad_side");
 
-		Meters {
-			sink, source,
-			sink_box, source_box,
-			sink_inputs_box, source_outputs_box,
-			sink_inputs: HashMap::new(),
-			source_outputs: HashMap::new(),
-			show_visualizers: true,
-			separate_channels: false,
-		}
-	}
+        Meters {
+            sink,
+            source,
+            sink_box,
+            source_box,
+            sink_inputs_box,
+            source_outputs_box,
+            sink_inputs: HashMap::new(),
+            source_outputs: HashMap::new(),
+            show_visualizers: true,
+            separate_channels: false,
+        }
+    }
 
+    /**
+     * Toggles the show visualizers setting, and returns its current state.
+     */
 
-	/**
-	 * Toggles the show visualizers setting, and returns its current state.
-	 */
+    fn toggle_visualizers(&mut self) -> bool {
+        self.show_visualizers = !self.show_visualizers;
+        self.show_visualizers
+    }
 
-	fn toggle_visualizers(&mut self) -> bool {
-		self.show_visualizers = !self.show_visualizers;
-		self.show_visualizers
-	}
+    /**
+     * Toggles the separate channels setting, and returns its current state.
+     */
 
-
-	/**
-	 * Toggles the separate channels setting, and returns its current state.
-	 */
-
-	fn toggle_separate_channels(&mut self) -> bool {
-		self.separate_channels = !self.separate_channels;
-		self.separate_channels
-	}
+    fn toggle_separate_channels(&mut self) -> bool {
+        self.separate_channels = !self.separate_channels;
+        self.separate_channels
+    }
 }
-
 
 /**
  * The main Myxer application window,
@@ -100,246 +98,321 @@ impl Meters {
  */
 
 pub struct Myxer {
-	pulse: Shared<Pulse>,
-	meters: Shared<Meters>,
+    pulse: Shared<Pulse>,
+    meters: Shared<Meters>,
 
-	profiles: Shared<Option<Profiles>>
+    profiles: Shared<Option<Profiles>>,
 }
 
 impl Myxer {
+    /**
+     * Initializes the main window.
+     *
+     * * `app` - The GTK application.
+     * * `pulse` - The Pulse store instance.
+     */
 
-	/**
-	 * Initializes the main window.
-	 *
-	 * * `app` - The GTK application.
-	 * * `pulse` - The Pulse store instance.
-	 */
+    pub fn new(app: &gtk::Application, pulse: &Shared<Pulse>) -> Self {
+        let window = gtk::ApplicationWindow::new(app);
+        let header = gtk::HeaderBar::new();
+        let stack = gtk::Stack::new();
 
-	pub fn new(app: &gtk::Application, pulse: &Shared<Pulse>) -> Self {
-		let window = gtk::ApplicationWindow::new(app);
-		let header = gtk::HeaderBar::new();
-		let stack = gtk::Stack::new();
-		
-		{
-			window.set_title("Volume Mixer");
-			window.set_icon_name(Some("multimedia-volume-control"));
+        {
+            window.set_title("Volume Mixer");
+            window.set_icon_name(Some("multimedia-volume-control"));
 
-			let geom = gdk::Geometry {
-				min_width: 580, min_height: 400,
-				max_width: 10000, max_height: 400,
-				base_width: -1, base_height: -1,
-				width_inc: -1, height_inc: -1,
-				min_aspect: 0.0, max_aspect: 0.0,
-				win_gravity: gdk::Gravity::Center
-			};
+            let geom = gdk::Geometry {
+                min_width: 580,
+                min_height: 400,
+                max_width: 10000,
+                max_height: 400,
+                base_width: -1,
+                base_height: -1,
+                width_inc: -1,
+                height_inc: -1,
+                min_aspect: 0.0,
+                max_aspect: 0.0,
+                win_gravity: gdk::Gravity::Center,
+            };
 
-			window.set_geometry_hints::<gtk::ApplicationWindow>(None, Some(&geom), gdk::WindowHints::MIN_SIZE | gdk::WindowHints::MAX_SIZE);
-			style::style(&window);
+            window.set_geometry_hints::<gtk::ApplicationWindow>(
+                None,
+                Some(&geom),
+                gdk::WindowHints::MIN_SIZE | gdk::WindowHints::MAX_SIZE,
+            );
+            style::style(&window);
 
-			let stack_switcher = gtk::StackSwitcher::new();
-			stack_switcher.set_stack(Some(&stack));
+            let stack_switcher = gtk::StackSwitcher::new();
+            stack_switcher.set_stack(Some(&stack));
 
-			header.set_show_close_button(true);
-			header.set_custom_title(Some(&stack_switcher));
+            header.set_show_close_button(true);
+            header.set_custom_title(Some(&stack_switcher));
 
-			let title_box = gtk::Box::new(gtk::Orientation::Vertical, 0);
-			let title = gtk::Label::new(Some("Volume Mixer"));
-			title.get_style_context().add_class("title");
-			title_box.pack_start(&title, true, true, 0);
-			header.pack_start(&title_box);
-			header.set_decoration_layout(Some("icon:minimize,close"));
-			
-			window.set_titlebar(Some(&header));
-		}
+            let title_box = gtk::Box::new(gtk::Orientation::Vertical, 0);
+            let title = gtk::Label::new(Some("Volume Mixer"));
+            title.get_style_context().add_class("title");
+            title_box.pack_start(&title, true, true, 0);
+            header.pack_start(&title_box);
+            header.set_decoration_layout(Some("icon:minimize,close"));
 
-		{
-			let prefs_button = gtk::Button::from_icon_name(Some("open-menu-symbolic"), gtk::IconSize::SmallToolbar);
-			prefs_button.get_style_context().add_class("flat");
-			prefs_button.set_widget_name("preferences");
-			prefs_button.set_can_focus(false);
-			header.pack_end(&prefs_button);
+            window.set_titlebar(Some(&header));
+        }
 
-			let prefs = gtk::PopoverMenu::new();
-			prefs.set_pointing_to(&gtk::Rectangle { x: 12, y: 32, width: 2, height: 2 });
-			prefs.set_relative_to(Some(&prefs_button));
-			prefs.set_border_width(6);
+        {
+            let prefs_button = gtk::Button::from_icon_name(
+                Some("open-menu-symbolic"),
+                gtk::IconSize::SmallToolbar,
+            );
+            prefs_button.get_style_context().add_class("flat");
+            prefs_button.set_widget_name("preferences");
+            prefs_button.set_can_focus(false);
+            header.pack_end(&prefs_button);
 
-			let prefs_box = gtk::Box::new(gtk::Orientation::Vertical, 0);
-			prefs.add(&prefs_box);
+            let prefs = gtk::PopoverMenu::new();
+            prefs.set_pointing_to(&gtk::Rectangle {
+                x: 12,
+                y: 32,
+                width: 2,
+                height: 2,
+            });
+            prefs.set_relative_to(Some(&prefs_button));
+            prefs.set_border_width(6);
 
-			let show_visualizers = gtk::ModelButton::new();
-			show_visualizers.set_property_text(Some("Visualize Peaks"));
-			show_visualizers.set_action_name(Some("app.show_visualizers"));
-			prefs_box.add(&show_visualizers);
+            let prefs_box = gtk::Box::new(gtk::Orientation::Vertical, 0);
+            prefs.add(&prefs_box);
 
-			let split_channels = gtk::ModelButton::new();
-			split_channels.set_property_text(Some("Split Channels"));
-			split_channels.set_action_name(Some("app.split_channels"));
-			prefs_box.add(&split_channels);
+            let show_visualizers = gtk::ModelButton::new();
+            show_visualizers.set_property_text(Some("Visualize Peaks"));
+            show_visualizers.set_action_name(Some("app.show_visualizers"));
+            prefs_box.add(&show_visualizers);
 
-			let card_profiles = gtk::ModelButton::new();
-			card_profiles.set_property_text(Some("Card Profiles..."));
-			card_profiles.set_action_name(Some("app.card_profiles"));
-			prefs_box.add(&card_profiles);
+            let split_channels = gtk::ModelButton::new();
+            split_channels.set_property_text(Some("Split Channels"));
+            split_channels.set_action_name(Some("app.split_channels"));
+            prefs_box.add(&split_channels);
 
-			prefs_box.pack_start(&gtk::Separator::new(gtk::Orientation::Horizontal), false, false, 4);
+            let card_profiles = gtk::ModelButton::new();
+            card_profiles.set_property_text(Some("Card Profiles..."));
+            card_profiles.set_action_name(Some("app.card_profiles"));
+            prefs_box.add(&card_profiles);
 
-			let about = gtk::ModelButton::new();
-			about.set_property_text(Some("About Myxer"));
-			about.set_action_name(Some("app.about"));
-			prefs_box.add(&about);
+            prefs_box.pack_start(
+                &gtk::Separator::new(gtk::Orientation::Horizontal),
+                false,
+                false,
+                4,
+            );
 
-			prefs_box.show_all();
-			prefs_button.connect_clicked(move |_| prefs.popup());
-		}
+            let about = gtk::ModelButton::new();
+            about.set_property_text(Some("About Myxer"));
+            about.set_action_name(Some("app.about"));
+            prefs_box.add(&about);
 
-		pulse.borrow_mut().connect();
-		let meters = Shared::new(Meters::new(pulse));
+            prefs_box.show_all();
+            prefs_button.connect_clicked(move |_| prefs.popup());
+        }
 
-		{
-			let output = gtk::Box::new(gtk::Orientation::Horizontal, 0);
-			output.pack_start(&meters.borrow_mut().sink_box, false, false, 0);
+        pulse.borrow_mut().connect();
+        let meters = Shared::new(Meters::new(pulse));
 
-			output.pack_start(&gtk::Separator::new(gtk::Orientation::Vertical), false, true, 0);
+        {
+            let output = gtk::Box::new(gtk::Orientation::Horizontal, 0);
+            output.pack_start(&meters.borrow_mut().sink_box, false, false, 0);
 
-			let output_scroller = gtk::ScrolledWindow::new::<gtk::Adjustment, gtk::Adjustment>(None, None);
-			output_scroller.set_policy(gtk::PolicyType::Automatic, gtk::PolicyType::Never);
-			output_scroller.get_style_context().add_class("bordered");
-			output.pack_start(&output_scroller, true, true, 0);
-			output_scroller.add(&meters.borrow().sink_inputs_box);
+            output.pack_start(
+                &gtk::Separator::new(gtk::Orientation::Vertical),
+                false,
+                true,
+                0,
+            );
 
-			let input = gtk::Box::new(gtk::Orientation::Horizontal, 0);
-			input.pack_start(&meters.borrow_mut().source_box, false, false, 0);
+            let output_scroller =
+                gtk::ScrolledWindow::new::<gtk::Adjustment, gtk::Adjustment>(None, None);
+            output_scroller.set_policy(gtk::PolicyType::Automatic, gtk::PolicyType::Never);
+            output_scroller.get_style_context().add_class("bordered");
+            output.pack_start(&output_scroller, true, true, 0);
+            output_scroller.add(&meters.borrow().sink_inputs_box);
 
-			input.pack_start(&gtk::Separator::new(gtk::Orientation::Vertical), false, true, 0);
+            let input = gtk::Box::new(gtk::Orientation::Horizontal, 0);
+            input.pack_start(&meters.borrow_mut().source_box, false, false, 0);
 
-			let input_scroller = gtk::ScrolledWindow::new::<gtk::Adjustment, gtk::Adjustment>(None, None);
-			input_scroller.set_policy(gtk::PolicyType::Automatic, gtk::PolicyType::Never);
-			input_scroller.get_style_context().add_class("bordered");
-			input.pack_start(&input_scroller, true, true, 0);
-			input_scroller.add(&meters.borrow().source_outputs_box);
+            input.pack_start(
+                &gtk::Separator::new(gtk::Orientation::Vertical),
+                false,
+                true,
+                0,
+            );
 
-			stack.add_titled(&output, "output", "Output");
-			stack.add_titled(&input, "input", "Input");
+            let input_scroller =
+                gtk::ScrolledWindow::new::<gtk::Adjustment, gtk::Adjustment>(None, None);
+            input_scroller.set_policy(gtk::PolicyType::Automatic, gtk::PolicyType::Never);
+            input_scroller.get_style_context().add_class("bordered");
+            input.pack_start(&input_scroller, true, true, 0);
+            input_scroller.add(&meters.borrow().source_outputs_box);
 
-			window.add(&stack);
-			window.show_all();
-		}
+            stack.add_titled(&output, "output", "Output");
+            stack.add_titled(&input, "input", "Input");
 
-		let profiles = Shared::new(None);
+            window.add(&stack);
+            window.show_all();
+        }
 
-		{
-			let actions = gio::SimpleActionGroup::new();
-			window.insert_action_group("app", Some(&actions));
+        let profiles = Shared::new(None);
 
-			let about = gio::SimpleAction::new("about", None);
-			about.connect_activate(|_, _| about::about());
-			actions.add_action(&about);
+        {
+            let actions = gio::SimpleActionGroup::new();
+            window.insert_action_group("app", Some(&actions));
 
-			let card_profiles = gio::SimpleAction::new("card_profiles", None);
-			let pulse = pulse.clone();
-			let window = window.clone();
-			let profiles = profiles.clone();
-			card_profiles.connect_activate(move |_, _| {
-				profiles.replace(Some(Profiles::new(&window, &pulse)));
-			});
-			actions.add_action(&card_profiles);
+            let about = gio::SimpleAction::new("about", None);
+            about.connect_activate(|_, _| about::about());
+            actions.add_action(&about);
 
-			let meters_clone = meters.clone();
-			let split_channels = gio::SimpleAction::new_stateful("split_channels", glib::VariantTy::new("bool").ok(), &false.to_variant());
-			split_channels.connect_activate(move |s, _| s.set_state(&meters_clone.borrow_mut().toggle_separate_channels().to_variant()));
-			actions.add_action(&split_channels);
+            let card_profiles = gio::SimpleAction::new("card_profiles", None);
+            let pulse = pulse.clone();
+            let window = window.clone();
+            let profiles = profiles.clone();
+            card_profiles.connect_activate(move |_, _| {
+                profiles.replace(Some(Profiles::new(&window, &pulse)));
+            });
+            actions.add_action(&card_profiles);
 
-			let meters_clone = meters.clone();
-			let show_visualizers = gio::SimpleAction::new_stateful("show_visualizers", glib::VariantTy::new("bool").ok(), &true.to_variant());
-			show_visualizers.connect_activate(move |s, _| s.set_state(&meters_clone.borrow_mut().toggle_visualizers().to_variant()));
-			actions.add_action(&show_visualizers);
-		}
+            let meters_clone = meters.clone();
+            let split_channels = gio::SimpleAction::new_stateful(
+                "split_channels",
+                glib::VariantTy::new("bool").ok(),
+                &false.to_variant(),
+            );
+            split_channels.connect_activate(move |s, _| {
+                s.set_state(
+                    &meters_clone
+                        .borrow_mut()
+                        .toggle_separate_channels()
+                        .to_variant(),
+                )
+            });
+            actions.add_action(&split_channels);
 
-		Self {
-			pulse: pulse.clone(),
-			meters,
-			profiles
-		}
-	}
+            let meters_clone = meters.clone();
+            let show_visualizers = gio::SimpleAction::new_stateful(
+                "show_visualizers",
+                glib::VariantTy::new("bool").ok(),
+                &true.to_variant(),
+            );
+            show_visualizers.connect_activate(move |s, _| {
+                s.set_state(&meters_clone.borrow_mut().toggle_visualizers().to_variant())
+            });
+            actions.add_action(&show_visualizers);
+        }
 
+        Self {
+            pulse: pulse.clone(),
+            meters,
+            profiles,
+        }
+    }
 
-	/**
-	 * Updates the app's widgets based on information stored in the Pulse instance.
-	 * Kills the Card Profiles window if it has been requested.
-	 */
+    /**
+     * Updates the app's widgets based on information stored in the Pulse instance.
+     * Kills the Card Profiles window if it has been requested.
+     */
 
-	pub fn update(&mut self) {
-		let mut kill = false;
-		if let Some(profiles) = self.profiles.borrow_mut().as_mut() { kill = !profiles.update(); }
-		if kill { self.profiles.replace(None); }
+    pub fn update(&mut self) {
+        let mut kill = false;
+        if let Some(profiles) = self.profiles.borrow_mut().as_mut() {
+            kill = !profiles.update();
+        }
+        if kill {
+            self.profiles.replace(None);
+        }
 
-		if self.pulse.borrow_mut().update() {
-			let pulse = self.pulse.borrow();
+        if self.pulse.borrow_mut().update() {
+            let pulse = self.pulse.borrow();
 
-			let mut meters = self.meters.borrow_mut();
+            let mut meters = self.meters.borrow_mut();
 
-			let offset = meters.sink.widget.get_allocation().height +
-				meters.sink.widget.get_margin_bottom() - meters.sink_inputs_box.get_allocation().height;
-			if offset != meters.sink.widget.get_margin_bottom() { meters.sink.widget.set_margin_bottom(offset) }
+            let offset = meters.sink.widget.get_allocation().height
+                + meters.sink.widget.get_margin_bottom()
+                - meters.sink_inputs_box.get_allocation().height;
+            if offset != meters.sink.widget.get_margin_bottom() {
+                meters.sink.widget.set_margin_bottom(offset)
+            }
 
-			let offset = meters.source.widget.get_allocation().height +
-				meters.source.widget.get_margin_bottom() - meters.source_outputs_box.get_allocation().height;
-			if offset != meters.source.widget.get_margin_bottom() { meters.source.widget.set_margin_bottom(offset) }
+            let offset = meters.source.widget.get_allocation().height
+                + meters.source.widget.get_margin_bottom()
+                - meters.source_outputs_box.get_allocation().height;
+            if offset != meters.source.widget.get_margin_bottom() {
+                meters.source.widget.set_margin_bottom(offset)
+            }
 
-			
-			let show = meters.show_visualizers;
-			let separate = meters.separate_channels;
+            let show = meters.show_visualizers;
+            let separate = meters.separate_channels;
 
+            if let Some(sink) = pulse.sinks.get(&pulse.active_sink) {
+                meters.sink.set_data(&sink.data);
+                meters.sink.split_channels(separate);
+                meters
+                    .sink
+                    .set_peak(if show { Some(sink.peak) } else { None });
+            }
 
-			if let Some(sink) = pulse.sinks.get(&pulse.active_sink) {
-				meters.sink.set_data(&sink.data);
-				meters.sink.split_channels(separate);
-				meters.sink.set_peak(if show { Some(sink.peak) } else { None });
-			}
+            for (index, input) in &pulse.sink_inputs {
+                let sink_inputs_box = meters.sink_inputs_box.clone();
 
-			for (index, input) in &pulse.sink_inputs {
-				let sink_inputs_box = meters.sink_inputs_box.clone();
+                let meter = meters
+                    .sink_inputs
+                    .entry(*index)
+                    .or_insert_with(|| StreamMeter::new(self.pulse.clone()));
+                if meter.widget.get_parent().is_none() {
+                    sink_inputs_box.pack_start(&meter.widget, false, false, 0);
+                }
+                meter.set_data(&input.data);
+                meter.split_channels(separate);
+                meter.set_peak(if show { Some(input.peak) } else { None });
+            }
 
-				let meter = meters.sink_inputs.entry(*index).or_insert_with(|| StreamMeter::new(self.pulse.clone()));
-				if meter.widget.get_parent().is_none() { sink_inputs_box.pack_start(&meter.widget, false, false, 0); }
-				meter.set_data(&input.data);
-				meter.split_channels(separate);
-				meter.set_peak(if show { Some(input.peak) } else { None });
-			}
+            let sink_inputs_box = meters.sink_inputs_box.clone();
+            meters.sink_inputs.retain(|index, meter| {
+                let keep = pulse.sink_inputs.contains_key(index);
+                if !keep {
+                    sink_inputs_box.remove(&meter.widget);
+                }
+                keep
+            });
 
-			let sink_inputs_box = meters.sink_inputs_box.clone();
-			meters.sink_inputs.retain(|index, meter| {
-				let keep = pulse.sink_inputs.contains_key(index);
-				if !keep { sink_inputs_box.remove(&meter.widget); }
-				keep
-			});
+            if let Some(source) = pulse.sources.get(&pulse.active_source) {
+                meters.source.set_data(&source.data);
+                meters.source.split_channels(separate);
+                meters
+                    .source
+                    .set_peak(if show { Some(source.peak) } else { None });
+            }
 
-			if let Some(source) = pulse.sources.get(&pulse.active_source) {
-				meters.source.set_data(&source.data);
-				meters.source.split_channels(separate);
-				meters.source.set_peak(if show { Some(source.peak) } else { None });
-			}
+            for (index, output) in &pulse.source_outputs {
+                let source_outputs_box = meters.source_outputs_box.clone();
 
-			for (index, output) in &pulse.source_outputs {
-				let source_outputs_box = meters.source_outputs_box.clone();
-				
-				let meter = meters.source_outputs.entry(*index).or_insert_with(|| StreamMeter::new(self.pulse.clone()));
-				if meter.widget.get_parent().is_none() { source_outputs_box.pack_start(&meter.widget, false, false, 0); }
-				meter.set_data(&output.data);
-				meter.split_channels(separate);
-				meter.set_peak(if show { Some(output.peak) } else { None });
-			}
+                let meter = meters
+                    .source_outputs
+                    .entry(*index)
+                    .or_insert_with(|| StreamMeter::new(self.pulse.clone()));
+                if meter.widget.get_parent().is_none() {
+                    source_outputs_box.pack_start(&meter.widget, false, false, 0);
+                }
+                meter.set_data(&output.data);
+                meter.split_channels(separate);
+                meter.set_peak(if show { Some(output.peak) } else { None });
+            }
 
-			let source_outputs_box = meters.source_outputs_box.clone();
-			meters.source_outputs.retain(|index, meter| {
-				let keep = pulse.source_outputs.contains_key(index);
-				if !keep { source_outputs_box.remove(&meter.widget); }
-				keep
-			});
+            let source_outputs_box = meters.source_outputs_box.clone();
+            meters.source_outputs.retain(|index, meter| {
+                let keep = pulse.source_outputs.contains_key(index);
+                if !keep {
+                    source_outputs_box.remove(&meter.widget);
+                }
+                keep
+            });
 
-			meters.sink_inputs_box.show_all();
-			meters.source_outputs_box.show_all();
-		}
-	}
+            meters.sink_inputs_box.show_all();
+            meters.source_outputs_box.show_all();
+        }
+    }
 }

--- a/src/window/profiles.rs
+++ b/src/window/profiles.rs
@@ -10,27 +10,27 @@ use crate::card::Card;
 use crate::pulse::Pulse;
 use crate::shared::Shared;
 
-
 /**
  * Stores the created Card widgets.
  */
 
 struct Cards {
-	cards: HashMap<u32, Card>,
-	cards_box: gtk::Box,
+    cards: HashMap<u32, Card>,
+    cards_box: gtk::Box,
 }
 
 impl Cards {
-	
-	/**
-	 * Initializes the structure.
-	 */
+    /**
+     * Initializes the structure.
+     */
 
-	pub fn new() -> Self {
-		Cards { cards: HashMap::new(), cards_box: gtk::Box::new(gtk::Orientation::Vertical, 8) }
-	}
+    pub fn new() -> Self {
+        Cards {
+            cards: HashMap::new(),
+            cards_box: gtk::Box::new(gtk::Orientation::Vertical, 8),
+        }
+    }
 }
-
 
 /**
  * The Card Profiles popup window.
@@ -38,76 +38,100 @@ impl Cards {
  */
 
 pub struct Profiles {
-	cards: Shared<Cards>,
-	pulse: Shared<Pulse>,
+    cards: Shared<Cards>,
+    pulse: Shared<Pulse>,
 
-	/** Indicates if the popup should remain open. */
-	live: Shared<bool>
+    /** Indicates if the popup should remain open. */
+    live: Shared<bool>,
 }
 
 impl Profiles {
+    /**
+     * Creates the Card Profiles window, and its contents.
+     */
 
-	/**
-	 * Creates the Card Profiles window, and its contents.
-	 */
+    pub fn new(parent: &gtk::ApplicationWindow, pulse: &Shared<Pulse>) -> Self {
+        let dialog = gtk::Dialog::with_buttons(
+            Some("Card Profiles"),
+            Some(parent),
+            gtk::DialogFlags::all(),
+            &[],
+        );
+        dialog.set_border_width(0);
 
-	pub fn new(parent: &gtk::ApplicationWindow, pulse: &Shared<Pulse>) -> Self {
-		let dialog = gtk::Dialog::with_buttons(Some("Card Profiles"), Some(parent), gtk::DialogFlags::all(), &[]);
-		dialog.set_border_width(0);
+        let live = Shared::new(true);
+        dialog.connect_response(|s, _| s.emit_close());
+        let live_clone = live.clone();
+        dialog.connect_close(move |_| {
+            live_clone.replace(false);
+        });
 
-		let live = Shared::new(true);
-		dialog.connect_response(|s, _| s.emit_close());
-		let live_clone = live.clone();
-		dialog.connect_close(move |_| { live_clone.replace(false); });
+        let geom = gdk::Geometry {
+            min_width: 450,
+            min_height: 550,
+            max_width: 450,
+            max_height: 10000,
+            base_width: -1,
+            base_height: -1,
+            width_inc: -1,
+            height_inc: -1,
+            min_aspect: 0.0,
+            max_aspect: 0.0,
+            win_gravity: gdk::Gravity::Center,
+        };
 
-		let geom = gdk::Geometry {
-			min_width: 450, min_height: 550,
-			max_width: 450, max_height: 10000,
-			base_width: -1, base_height: -1,
-			width_inc: -1, height_inc: -1,
-			min_aspect: 0.0, max_aspect: 0.0,
-			win_gravity: gdk::Gravity::Center
-		};
+        dialog.set_geometry_hints::<gtk::Dialog>(
+            None,
+            Some(&geom),
+            gdk::WindowHints::MIN_SIZE | gdk::WindowHints::MAX_SIZE,
+        );
+        let cards = Shared::new(Cards::new());
 
-		dialog.set_geometry_hints::<gtk::Dialog>(None, Some(&geom), gdk::WindowHints::MIN_SIZE | gdk::WindowHints::MAX_SIZE);
-		let cards = Shared::new(Cards::new());
-		
-		let scroller = gtk::ScrolledWindow::new::<gtk::Adjustment, gtk::Adjustment>(None, None);
-		scroller.set_policy(gtk::PolicyType::Never, gtk::PolicyType::Automatic);
-		dialog.get_content_area().pack_start(&scroller, true, true, 0);
-		dialog.get_content_area().set_border_width(0);
-		scroller.add(&cards.borrow().cards_box);
+        let scroller = gtk::ScrolledWindow::new::<gtk::Adjustment, gtk::Adjustment>(None, None);
+        scroller.set_policy(gtk::PolicyType::Never, gtk::PolicyType::Automatic);
+        dialog
+            .get_content_area()
+            .pack_start(&scroller, true, true, 0);
+        dialog.get_content_area().set_border_width(0);
+        scroller.add(&cards.borrow().cards_box);
 
-		dialog.show_all();
+        dialog.show_all();
 
-		Self {
-			live,
-			cards,
-			pulse: pulse.clone()
-		}
-	}
+        Self {
+            live,
+            cards,
+            pulse: pulse.clone(),
+        }
+    }
 
+    /**
+     * Updates the card widgets to the latest information,
+     * returns a boolean indicating if the window should continue to be open or not.
+     */
 
-	/**
-	 * Updates the card widgets to the latest information,
-	 * returns a boolean indicating if the window should continue to be open or not.
-	 */
+    pub fn update(&mut self) -> bool {
+        let pulse = self.pulse.borrow_mut();
+        let mut cards = self.cards.borrow_mut();
+        for (index, data) in &pulse.cards {
+            let cards_box = cards.cards_box.clone();
 
-	pub fn update(&mut self) -> bool {
-		let pulse = self.pulse.borrow_mut();
-		let mut cards = self.cards.borrow_mut();
-		for (index, data) in &pulse.cards {
-			let cards_box = cards.cards_box.clone();
-			
-			let card = cards.cards.entry(*index).or_insert_with(|| Card::new(Some(self.pulse.clone())));
-			if card.widget.get_parent().is_none() {
-				cards_box.pack_start(&card.widget, false, false, 0);
-				cards_box.pack_start(&gtk::Separator::new(gtk::Orientation::Horizontal), false, false, 0);
-			}
-			card.set_data(&data);
-		}
+            let card = cards
+                .cards
+                .entry(*index)
+                .or_insert_with(|| Card::new(Some(self.pulse.clone())));
+            if card.widget.get_parent().is_none() {
+                cards_box.pack_start(&card.widget, false, false, 0);
+                cards_box.pack_start(
+                    &gtk::Separator::new(gtk::Orientation::Horizontal),
+                    false,
+                    false,
+                    0,
+                );
+            }
+            card.set_data(&data);
+        }
 
-		cards.cards_box.show_all();
-		*self.live.borrow()
-	}
+        cards.cards_box.show_all();
+        *self.live.borrow()
+    }
 }

--- a/src/window/style.rs
+++ b/src/window/style.rs
@@ -6,7 +6,6 @@
 
 use gtk::prelude::*;
 
-
 /**
  * Applies application-specific styles to the specified window.
  * Generates a few GTK widgets to steal their theme colors using deprecated methods.
@@ -17,35 +16,62 @@ use gtk::prelude::*;
  */
 
 pub fn style(window: &gtk::ApplicationWindow) {
-	let provider = gtk::CssProvider::new();
+    let provider = gtk::CssProvider::new();
 
-	let mut s = String::new();
+    let mut s = String::new();
 
-	let mut add_color = |identifier: &str, color: &gdk::RGBA| {
-		s.push_str("@define-color ");
-		s.push_str(identifier);
-		s.push_str(" ");
-		s.push_str(&colorsys::Rgb::new(color.red * 255.0, color.green * 255.0, color.blue * 255.0, None).to_css_string());
-		s.push_str(";\n");
-	};
+    let mut add_color = |identifier: &str, color: &gdk::RGBA| {
+        s.push_str("@define-color ");
+        s.push_str(identifier);
+        s.push_str(" ");
+        s.push_str(
+            &colorsys::Rgb::new(
+                color.red * 255.0,
+                color.green * 255.0,
+                color.blue * 255.0,
+                None,
+            )
+            .to_css_string(),
+        );
+        s.push_str(";\n");
+    };
 
-	let row = gtk::ListBoxRow::new();
-	let button = gtk::Button::new();
-	add_color("scale_color", &row.get_style_context().get_background_color(gtk::StateFlags::SELECTED));
-	add_color("background_color", &window.get_style_context().get_background_color(gtk::StateFlags::NORMAL));
-	add_color("foreground_color", &button.get_style_context().get_color(gtk::StateFlags::NORMAL));
+    let row = gtk::ListBoxRow::new();
+    let button = gtk::Button::new();
+    add_color(
+        "scale_color",
+        &row.get_style_context()
+            .get_background_color(gtk::StateFlags::SELECTED),
+    );
+    add_color(
+        "background_color",
+        &window
+            .get_style_context()
+            .get_background_color(gtk::StateFlags::NORMAL),
+    );
+    add_color(
+        "foreground_color",
+        &button
+            .get_style_context()
+            .get_color(gtk::StateFlags::NORMAL),
+    );
 
-	s.push_str(STYLE);
+    s.push_str(STYLE);
 
-	provider.load_from_data(s.as_bytes()).expect("Failed to load CSS.");
-	gtk::StyleContext::add_provider_for_screen(&gdk::Screen::get_default().expect("Error initializing GTK CSS provider."),
-		&provider, gtk::STYLE_PROVIDER_PRIORITY_APPLICATION);
+    provider
+        .load_from_data(s.as_bytes())
+        .expect("Failed to load CSS.");
+    gtk::StyleContext::add_provider_for_screen(
+        &gdk::Screen::get_default().expect("Error initializing GTK CSS provider."),
+        &provider,
+        gtk::STYLE_PROVIDER_PRIORITY_APPLICATION,
+    );
 }
 
 /**
  * The custom stylesheet used by Myxer.
  */
- 
+
 const STYLE: &'static str = r#"
 .title {
 	padding-left: 3px;


### PR DESCRIPTION
This PR applies rustfmt to all code files, thus changing practically every line ._.
If there are specific code-style opinions that you disagree with here, rustfmt allows to change a good bit about code style in configuration, thus this can be adjusted.

This would fix #4, with that drastically improving consistency in style as well as making it possible for contributions to also follow a consistent code style.
