### PR TITLE
Created a simple PKGBUILD

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,0 +1,24 @@
+pkgname=myxer
+_pkgname=Myxer
+pkgver=1.1.3
+pkgrel=1
+pkgdesc='A modern Volume Mixer for PulseAudio, built with you in mind.'
+url='https://github.com/Aurailus/Myxer'
+source=("$pkgname-$pkgver.tar.gz::$url/archive/refs/tags/$pkgver.tar.gz")
+arch=('any')
+license=('GPL3')
+makedepends=('cargo')
+depends=('pulseaudio' 'gtk3')
+sha256sums=('4784746fd491d51397b3c47eb5ed5cf3f04ba54a116c192620bb532db2c2d550')
+
+build () {
+  cd "$srcdir/$_pkgname-$pkgver"
+
+  cargo build --release
+}
+
+package() {
+  cd "$srcdir/$_pkgname-$pkgver"
+
+  install -Dm755 target/release/$pkgname "${pkgdir}/usr/bin/myxer"
+}


### PR DESCRIPTION
Hello!

This PR adds a simple PKGBUILD to make it easier to install Myxer on Arch-based Linux distributions.
It is based on releases, not on git commits. So, on every release, it should be updated.
I'm not really experienced in creating PKGBUILDs, but I believe this one should work for most users.

Any suggestion is welcome and appreciated, of course.