### PR TITLE
Use a fallback sequence for device names

### DIFF
--- a/src/pulse.rs
+++ b/src/pulse.rs
@@ -415,7 +415,10 @@ impl Pulse {
 			if let ListResult::Item(item) = result {
 				tx.send(TxMessage::CardUpdate(CardData {
 					index: item.index,
-					name: item.proplist.get_str("device.description").unwrap_or("".to_owned()),
+					name: item.proplist.get_str("device.description")
+							.or_else(|| item.proplist.get_str("device.alias"))
+							.or_else(|| item.proplist.get_str("device.name"))
+							.unwrap_or_else(|| "".to_owned()),
 					icon: item.proplist.get_str("device.icon_name").unwrap_or_else(|| "audio-card-pci".to_owned()),
 					profiles: item.profiles.iter().map(|p| (p.name.as_ref().unwrap().clone().into_owned(),
 						p.description.as_ref().unwrap().clone().into_owned())).collect(),


### PR DESCRIPTION
My Bluetooth sound card doesn't provide a device.description, leaving it as an "Unknown Card" on display; in other tools it shows just fine.

This PR adds a fallback sequence; it is not based on any good descriptions of these properties but on the observations made here (device.alias is the name I gave this in blueman, and thus is a slightly better name than device.name which is a hardware path for the built-in ones so should probably come last). It's not the sequence pavucontrol uses (pavucontrol shows the device.name over the device.alias), but it may ultimately be a matter of taste what to pick.