### PR TITLE
fix volume reset when unmuting by clicking the slider

### DIFF
--- a/src/meter/base_meter.rs
+++ b/src/meter/base_meter.rs
@@ -165,7 +165,7 @@ impl dyn Meter {
 
 					let pulse = pulse.borrow_mut();
 					pulse.set_volume(t, index, volumes);
-					if volumes.max().0 > 0 { pulse.set_muted(t, index, false); }
+					if volumes.max().0 > 0 { pulse.set_muted(t, index, false, false); }
 					gtk::Inhibit(false)
 				});
 
@@ -182,7 +182,7 @@ impl dyn Meter {
 				volumes.set(channels, Volume(value as u32));
 				let pulse = pulse.borrow_mut();
 				pulse.set_volume(t, index, volumes);
-				if volumes.max().0 > 0 { pulse.set_muted(t, index, false); }
+				if volumes.max().0 > 0 { pulse.set_muted(t, index, false, false); }
 				gtk::Inhibit(false)
 			});
 			scales_box.pack_start(&scale, false, false, 0);

--- a/src/meter/sink_meter.rs
+++ b/src/meter/sink_meter.rs
@@ -69,7 +69,7 @@ impl SinkMeter {
 		if self.s_id.is_some() { self.widgets.status.disconnect(glib::signal::SignalHandlerId::from_glib(self.s_id.as_ref().unwrap().to_glib())) }
 		self.s_id = Some(self.widgets.status.connect_clicked(move |status| {
 			pulse.borrow_mut().set_muted(t, index,
-				!status.get_style_context().has_class("muted"));
+				!status.get_style_context().has_class("muted"), true);
 		}));
 
 		let pulse = self.pulse.clone();

--- a/src/meter/source_meter.rs
+++ b/src/meter/source_meter.rs
@@ -71,7 +71,7 @@ impl SourceMeter {
 			glib::signal::SignalHandlerId::from_glib(self.s_id.as_ref().unwrap().to_glib())) }
 		self.s_id = Some(self.widgets.status.connect_clicked(move |status| {
 			pulse.borrow_mut().set_muted(t, index,
-				!status.get_style_context().has_class("muted"));
+				!status.get_style_context().has_class("muted"), true);
 		}));
 
 		let pulse = self.pulse.clone();

--- a/src/meter/stream_meter.rs
+++ b/src/meter/stream_meter.rs
@@ -67,7 +67,7 @@ impl StreamMeter {
 
 		if self.b_id.is_some() { self.widgets.status.disconnect(glib::signal::SignalHandlerId::from_glib(self.b_id.as_ref().unwrap().to_glib())) }
 		self.b_id = Some(self.widgets.status.connect_clicked(move |status| {
-			pulse.borrow_mut().set_muted(t, index, !status.get_style_context().has_class("muted"));
+			pulse.borrow_mut().set_muted(t, index, !status.get_style_context().has_class("muted"), true);
 		}));
 	}
 

--- a/src/pulse.rs
+++ b/src/pulse.rs
@@ -290,9 +290,9 @@ impl Pulse {
 	 * * `mute`  - Whether the stream should be muted or not.
 	 */
 
-	pub fn set_muted(&self, t: StreamType, index: u32, mute: bool) {
+	pub fn set_muted(&self, t: StreamType, index: u32, mute: bool, zero_volume_reset: bool) {
 		// If unmuting a stream that has been set to 0 volume, it should be reset to full.
-		if !mute {
+		if !mute && zero_volume_reset {
 			let entry = match t {
 				StreamType::Sink => self.sinks.get(&index),
 				StreamType::SinkInput => self.sink_inputs.get(&index),


### PR DESCRIPTION
Fixes #24

This happened because when "set_muted" is called to unmute a meter, it checks if the volume is 0% on both sides and resets them to 100% if it is.

However, the volume it got was under some kind of latency and, when unmuting by clicking the slider, "set_muted" still thinks the volume is 0% (from both sides), thus resetting the volume to 100% anyway.

By setting the variable "zero_volume_reset" i have made sure that the volume is **not** reset when unmuting by clicking the slider, but only when clicking the button directly.